### PR TITLE
Fix: MET-320 collapse sidebar when zoom

### DIFF
--- a/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
+++ b/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
@@ -42,7 +42,7 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
     if (!sidebar && width > 1023) setSidebar(true);
     else if (sidebar && width <= 1023) setSidebar(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width]);
+  }, [width > 1023]);
 
   const handleOpen = (item: string) => {
     setActive(item !== active ? item : null);


### PR DESCRIPTION
## Changes for UI
Issue: Reference: https://cardanofoundation.atlassian.net/browse/MET-320.
Resolve: 
Change effect dependency from "with" to "with >1023" (tablet breakpoint) because sidebar collapse action is only needed when changing devices, not when zooming