### PR TITLE
fix: differentiate contract and address when search

### DIFF
--- a/src/types/WalletAddress.d.ts
+++ b/src/types/WalletAddress.d.ts
@@ -17,6 +17,7 @@ interface WalletAddress {
     }
   ];
   stakeAddress: string;
+  isContract: boolean;
 }
 
 interface WalletStake {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,6 +6,7 @@ type FilterParams =
   | "tokens"
   | "stakes"
   | "addresses"
+  | "contract"
   | "delegations/pool-detail-header";
 
 interface SearchParams {


### PR DESCRIPTION
Issue: Navigate to wallet address detail page when search by contract address.
Reason: Contract address is also a wallet address.
Fixed: Add isContract field and checking before navigating