### PR TITLE
fix: show text when script not found in script modal

### DIFF
--- a/src/components/ScriptModal/index.tsx
+++ b/src/components/ScriptModal/index.tsx
@@ -80,6 +80,11 @@ const ScriptModal: React.FC<ScriptModalProps> = ({ policy, ...props }) => {
                   rootName={false}
                 />
               )}
+              {!loading && !data?.policyScript && (
+                <Box textAlign={"center"} py={2} color={({ palette }) => palette.grey[300]}>
+                  Script not found
+                </Box>
+              )}
             </ViewJson>
           </>
         )}


### PR DESCRIPTION
Reference: https://cardanofoundation.atlassian.net/jira/software/c/projects/MET/issues/MET-543