### PR TITLE
Bugfix/met 408 add last updated message

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -16,9 +16,10 @@ import ADAicon from "../../commons/ADAIcon";
 interface BlockOverviewProps {
   data: BlockDetail | null;
   loading: boolean;
+  lastUpdated: number;
 }
 
-const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading }) => {
+const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdated }) => {
   const renderConfirmationTag = () => {
     if (data && data.confirmation) {
       if (data.confirmation <= 2) {
@@ -124,6 +125,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading }) => {
       hash={data?.hash}
       bookmarkData={`${data?.blockNo || ""}`}
       title={"Block detail"}
+      lastUpdated={lastUpdated}
       epoch={
         data && {
           no: data.epochNo,

--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -11,6 +11,7 @@ import { Box } from "@mui/material";
 import CustomTooltip from "../../commons/CustomTooltip";
 import RateWithIcon from "../../commons/RateWithIcon";
 import { API } from "../../../commons/utils/api";
+import { REFRESH_TIMES } from "../../../commons/utils/constants";
 
 const DelegationLists: React.FC = () => {
   const history = useHistory();
@@ -20,12 +21,12 @@ const DelegationLists: React.FC = () => {
   const [size, setSize] = useState(50);
   const [sort, setSort] = useState<string>("");
   const tableRef = useRef(null);
-  const fetchData = useFetchList<Delegators>(API.DELEGATION.POOL_LIST, {
-    page: page - 1,
-    size,
-    search,
-    sort,
-  });
+  const fetchData = useFetchList<Delegators>(
+    API.DELEGATION.POOL_LIST,
+    { page: page - 1, size, search, sort },
+    false,
+    REFRESH_TIMES.POOLS
+  );
 
   const columns: Column<Delegators & { adaFake: number; feeFake: number }>[] = [
     {

--- a/src/components/DelegationPool/DelegationOverview/index.tsx
+++ b/src/components/DelegationPool/DelegationOverview/index.tsx
@@ -7,83 +7,101 @@ import { details } from "../../../commons/routers";
 import { API } from "../../../commons/utils/api";
 import { MAX_SLOT_EPOCH, REFRESH_TIMES } from "../../../commons/utils/constants";
 import { formatADAFull, numberWithCommas } from "../../../commons/utils/helper";
-import { StyledCard, StyledImg, StyledLinearProgress, StyledSkeleton } from "./styles";
+import { StyledCard, StyledImg, StyledLinearProgress, StyledSkeleton, TimeDuration } from "./styles";
+import Card from "../../commons/Card";
 
 const OverViews: React.FC = () => {
-  const { data, loading } = useFetch<OverViewDelegation>(API.DELEGATION.HEADER, undefined, false, REFRESH_TIMES.POOLS);
+  const { data, loading, lastUpdated } = useFetch<OverViewDelegation>(
+    API.DELEGATION.HEADER,
+    undefined,
+    false,
+    REFRESH_TIMES.POOLS
+  );
 
   if (loading) {
     return (
-      <Grid container spacing={2}>
-        <Grid item xl={4} md={6} xs={12}>
-          <StyledSkeleton variant="rectangular" />
+      <Card title="Delegation Pools Explorer">
+        <Grid container spacing={2}>
+          <Grid item xl={4} md={6} xs={12}>
+            <StyledSkeleton variant="rectangular" />
+          </Grid>
+          <Grid item xl={4} md={6} xs={12}>
+            <StyledSkeleton variant="rectangular" />
+          </Grid>
+          <Grid item xl={4} md={6} xs={12}>
+            <StyledSkeleton variant="rectangular" />
+          </Grid>
         </Grid>
-        <Grid item xl={4} md={6} xs={12}>
-          <StyledSkeleton variant="rectangular" />
-        </Grid>
-        <Grid item xl={4} md={6} xs={12}>
-          <StyledSkeleton variant="rectangular" />
-        </Grid>
-      </Grid>
+      </Card>
     );
   }
 
   const duration = moment.duration(data?.countDownEndTime || 0, "seconds");
 
   return (
-    <Grid container spacing={2}>
-      <Grid item xl={4} md={6} xs={12}>
-        <StyledCard.Container>
-          <StyledCard.Content>
-            <StyledCard.Title>Epoch</StyledCard.Title>
-            <StyledCard.Link to={details.epoch(data?.epochNo)}>{data?.epochNo}</StyledCard.Link>
-            <Box component="span" sx={{ color: theme => theme.palette.grey[400] }}>
-              End in:{" "}
-              <StyledCard.Comment>
-                {duration.days()} day {duration.hours()} hours {duration.minutes()} minutes
-              </StyledCard.Comment>
-            </Box>
-          </StyledCard.Content>
-          <StyledImg src={CurentEpochIcon} alt="Clock" />
-        </StyledCard.Container>
-      </Grid>
-      <Grid item xl={4} md={6} xs={12}>
-        <Box>
-          <Box bgcolor={theme => theme.palette.common.white} boxShadow={theme => theme.shadow.card} borderRadius="12px">
-            <StyledCard.Container style={{ boxShadow: "none" }}>
-              <StyledCard.Content>
-                <StyledCard.Title>Slot</StyledCard.Title>
-                <StyledCard.Value>
-                  {data?.epochSlotNo}
-                  <Box component="span" sx={{ color: theme => theme.palette.text.hint, fontWeight: "400" }}>
-                    / {MAX_SLOT_EPOCH}
-                  </Box>
-                </StyledCard.Value>
-              </StyledCard.Content>
-              <StyledImg src={RocketBackground} alt="Rocket" />
-            </StyledCard.Container>
-            <Box position={"relative"} top={-30} px={4}>
-              <StyledLinearProgress variant="determinate" value={((data?.epochSlotNo || 0) / MAX_SLOT_EPOCH) * 100} />
+    <Card
+      title="Delegation Pools Explorer"
+      extra={<TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>}
+    >
+      <TimeDuration mobile={1}>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>
+      <Grid container spacing={2}>
+        <Grid item xl={4} md={6} xs={12}>
+          <StyledCard.Container>
+            <StyledCard.Content>
+              <StyledCard.Title>Epoch</StyledCard.Title>
+              <StyledCard.Link to={details.epoch(data?.epochNo)}>{data?.epochNo}</StyledCard.Link>
+              <Box component="span" sx={{ color: theme => theme.palette.grey[400] }}>
+                End in:{" "}
+                <StyledCard.Comment>
+                  {duration.days()} day {duration.hours()} hours {duration.minutes()} minutes
+                </StyledCard.Comment>
+              </Box>
+            </StyledCard.Content>
+            <StyledImg src={CurentEpochIcon} alt="Clock" />
+          </StyledCard.Container>
+        </Grid>
+        <Grid item xl={4} md={6} xs={12}>
+          <Box>
+            <Box
+              bgcolor={theme => theme.palette.common.white}
+              boxShadow={theme => theme.shadow.card}
+              borderRadius="12px"
+            >
+              <StyledCard.Container style={{ boxShadow: "none" }}>
+                <StyledCard.Content>
+                  <StyledCard.Title>Slot</StyledCard.Title>
+                  <StyledCard.Value>
+                    {data?.epochSlotNo}
+                    <Box component="span" sx={{ color: theme => theme.palette.text.hint, fontWeight: "400" }}>
+                      / {MAX_SLOT_EPOCH}
+                    </Box>
+                  </StyledCard.Value>
+                </StyledCard.Content>
+                <StyledImg src={RocketBackground} alt="Rocket" />
+              </StyledCard.Container>
+              <Box position={"relative"} top={-30} px={4}>
+                <StyledLinearProgress variant="determinate" value={((data?.epochSlotNo || 0) / MAX_SLOT_EPOCH) * 100} />
+              </Box>
             </Box>
           </Box>
-        </Box>
+        </Grid>
+        <Grid item xl={4} md={6} xs={12}>
+          <StyledCard.Container>
+            <StyledCard.Content style={{ flex: 1 }}>
+              <StyledCard.Title>Live Stake</StyledCard.Title>
+              <StyledCard.Value>{formatADAFull(data?.liveStake)}</StyledCard.Value>
+            </StyledCard.Content>
+            <StyledCard.Content style={{ flex: 1 }}>
+              <StyledCard.Title>Delegators</StyledCard.Title>
+              <StyledCard.Value>{numberWithCommas(data?.delegators)}</StyledCard.Value>
+            </StyledCard.Content>
+            <Box flex={"1"}>
+              <StyledImg src={LiveStakeIcon} alt="Rocket" />
+            </Box>
+          </StyledCard.Container>
+        </Grid>
       </Grid>
-      <Grid item xl={4} md={6} xs={12}>
-        <StyledCard.Container>
-          <StyledCard.Content style={{ flex: 1 }}>
-            <StyledCard.Title>Live Stake</StyledCard.Title>
-            <StyledCard.Value>{formatADAFull(data?.liveStake)}</StyledCard.Value>
-          </StyledCard.Content>
-          <StyledCard.Content style={{ flex: 1 }}>
-            <StyledCard.Title>Delegators</StyledCard.Title>
-            <StyledCard.Value>{numberWithCommas(data?.delegators)}</StyledCard.Value>
-          </StyledCard.Content>
-          <Box flex={"1"}>
-            <StyledImg src={LiveStakeIcon} alt="Rocket" />
-          </Box>
-        </StyledCard.Container>
-      </Grid>
-    </Grid>
+    </Card>
   );
 };
 

--- a/src/components/DelegationPool/DelegationOverview/styles.ts
+++ b/src/components/DelegationPool/DelegationOverview/styles.ts
@@ -63,3 +63,15 @@ export const StyledCard = {
     color: ${props => props.theme.palette.primary.main};
   `,
 };
+
+export const TimeDuration = styled("small")<{ mobile?: number }>(({ theme, mobile }) => ({
+  color: theme.palette.grey[400],
+  display: mobile ? "none" : "block",
+  textAlign: "left",
+  paddingTop: "1rem",
+  [theme.breakpoints.down("sm")]: {
+    display: mobile ? "block" : "none",
+    paddingTop: 0,
+    margin: "-20px 0px 20px",
+  },
+}));

--- a/src/components/EpochDetail/EpochOverview/index.tsx
+++ b/src/components/EpochDetail/EpochOverview/index.tsx
@@ -15,9 +15,10 @@ import ADAicon from "../../commons/ADAIcon";
 interface EpochOverviewProps {
   data: IDataEpoch | null;
   loading: boolean;
+  lastUpdated: number;
 }
 
-const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading }) => {
+const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdated }) => {
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
   const slot = data && data?.no === currentEpoch?.no ? currentEpoch.slot : MAX_SLOT_EPOCH;
 
@@ -86,6 +87,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading }) => {
       type="EPOCH"
       bookmarkData={`${data?.no || ""}`}
       title={"Epoch detail"}
+      lastUpdated={lastUpdated}
       epoch={
         data && {
           no: data.no,

--- a/src/components/Home/LatestTransactions/index.tsx
+++ b/src/components/Home/LatestTransactions/index.tsx
@@ -23,13 +23,16 @@ import {
   BlankImage,
   RowItem,
   HeaderStatus,
+  Actions,
+  TimeDuration,
 } from "./style";
 import useFetch from "../../../commons/hooks/useFetch";
 import { TRANSACTION_STATUS } from "../../../commons/utils/constants";
 import { useScreen } from "../../../commons/hooks/useScreen";
+import moment from "moment";
 
 const LatestTransactions: React.FC = () => {
-  const { data, initialized } = useFetch<CurrentTransactions[]>(
+  const { data, initialized, lastUpdated } = useFetch<CurrentTransactions[]>(
     API.TRANSACTION.CURRENT,
     undefined,
     false,
@@ -42,7 +45,10 @@ const LatestTransactions: React.FC = () => {
     <TransactionContainer>
       <Header>
         <Title>Latest Transactions</Title>
-        <ViewAllButton to={routers.TRANSACTION_LIST} />
+        <Actions>
+          <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>
+          <ViewAllButton to={routers.TRANSACTION_LIST} />
+        </Actions>
       </Header>
       {
         <Grid container spacing={{ sm: 2 }}>

--- a/src/components/Home/LatestTransactions/style.ts
+++ b/src/components/Home/LatestTransactions/style.ts
@@ -17,6 +17,7 @@ export const Header = styled(Box)`
   gap: 10px;
   @media screen and (max-width: ${props => props.theme.breakpoints.values.sm}px) {
     padding: 0 15px;
+    margin-bottom: 2.5rem;
   }
 `;
 
@@ -36,6 +37,26 @@ export const Title = styled("h3")`
     background: var(--color-green-light);
   }
 `;
+
+export const Actions = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "flex-end",
+  alignItems: "center",
+  gap: 15,
+  position: "relative",
+}));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  [theme.breakpoints.down("sm")]: {
+    position: "absolute",
+    top: "100%",
+    right: 0,
+    paddingTop: 10,
+    whiteSpace: "nowrap",
+  },
+}));
 
 export const Item = styled(BoxRaised)`
   display: block;

--- a/src/components/Home/TopDelegationPools/index.tsx
+++ b/src/components/Home/TopDelegationPools/index.tsx
@@ -6,12 +6,14 @@ import { formatADAFull, formatPercent } from "../../../commons/utils/helper";
 import ViewAllButton from "../../commons/ViewAllButton";
 import { Column } from "../../commons/Table";
 import {
+  Actions,
   DelegateTable,
   Header,
   PoolName,
   ProgressContainer,
   ProgressTitle,
   StyledLinearProgress,
+  TimeDuration,
   Title,
   TopDelegateContainer,
 } from "./style";
@@ -20,11 +22,12 @@ import CustomTooltip from "../../commons/CustomTooltip";
 import { Box } from "@mui/system";
 import { API } from "../../../commons/utils/api";
 import { REFRESH_TIMES } from "../../../commons/utils/constants";
+import moment from "moment";
 
 interface Props {}
 
 const TopDelegationPools: React.FC<Props> = () => {
-  const { data, loading, initialized } = useFetch<DelegationPool[]>(
+  const { data, loading, initialized, lastUpdated } = useFetch<DelegationPool[]>(
     `${API.DELEGATION.TOP}?page=1&size=4`,
     undefined,
     false,
@@ -83,7 +86,10 @@ const TopDelegationPools: React.FC<Props> = () => {
     <TopDelegateContainer>
       <Header>
         <Title>Top Delegation Pools</Title>
-        <ViewAllButton to={routers.DELEGATION_POOLS} />
+        <Actions>
+          <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>
+          <ViewAllButton to={routers.DELEGATION_POOLS} />
+        </Actions>
       </Header>
       <DelegateTable
         loading={loading}

--- a/src/components/Home/TopDelegationPools/style.ts
+++ b/src/components/Home/TopDelegationPools/style.ts
@@ -18,6 +18,9 @@ export const Header = styled(Box)`
   align-items: center;
   margin-bottom: 0.5rem;
   gap: 10px;
+  ${props => props.theme.breakpoints.down("sm")} {
+    margin-bottom: 1.5rem;
+  }
 `;
 
 export const Title = styled("h3")`
@@ -36,6 +39,26 @@ export const Title = styled("h3")`
     background: var(--color-green-light);
   }
 `;
+
+export const Actions = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "flex-end",
+  alignItems: "center",
+  gap: 15,
+  position: "relative",
+}));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  [theme.breakpoints.down("sm")]: {
+    position: "absolute",
+    top: "100%",
+    right: 0,
+    paddingTop: 10,
+    whiteSpace: "nowrap",
+  },
+}));
 
 export const DelegateTable = styled(Table)`
   overflow-x: auto;

--- a/src/components/StakeDetail/StakeOverview/index.tsx
+++ b/src/components/StakeDetail/StakeOverview/index.tsx
@@ -6,12 +6,7 @@ import totalStakeIcon from "../../../commons/resources/icons/totalStake.svg";
 import rewardIcon from "../../../commons/resources/icons/reward.svg";
 import rewardWithdrawIcon from "../../../commons/resources/icons/rewardWithdraw.svg";
 import { formatADAFull } from "../../../commons/utils/helper";
-import {
-  ButtonModal,
-  StyledFlexValue,
-  StyledLink,
-  TitleCard,
-} from "./styles";
+import { ButtonModal, StyledFlexValue, StyledLink, TitleCard } from "./styles";
 import { useParams } from "react-router-dom";
 import ModalAllAddress from "../ModalAllAddress";
 import CustomTooltip from "../../commons/CustomTooltip";
@@ -21,8 +16,9 @@ import ADAicon from "../../commons/ADAIcon";
 interface Props {
   data: IStakeKeyDetail | null;
   loading: boolean;
+  lastUpdated: number;
 }
-const StakeOverview: React.FC<Props> = ({ data, loading }) => {
+const StakeOverview: React.FC<Props> = ({ data, loading, lastUpdated }) => {
   const [open, setOpen] = useState(false);
   const { stakeId } = useParams<{ stakeId: string }>();
   const listOverview = [
@@ -100,6 +96,7 @@ const StakeOverview: React.FC<Props> = ({ data, loading }) => {
       stakeKeyStatus={data?.status}
       listItem={listOverview}
       loading={loading}
+      lastUpdated={lastUpdated}
     />
   );
 };

--- a/src/components/TransactionDetail/TransactionOverview/index.tsx
+++ b/src/components/TransactionDetail/TransactionOverview/index.tsx
@@ -25,9 +25,10 @@ import ADAicon from "../../commons/ADAIcon";
 interface Props {
   data: Transaction | null;
   loading: boolean;
+  lastUpdated: number;
 }
 
-const TransactionOverview: React.FC<Props> = ({ data, loading }) => {
+const TransactionOverview: React.FC<Props> = ({ data, loading, lastUpdated }) => {
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
   const [openListInput, setOpenListInput] = useState(false);
   const [openListOutput, setOpenListOutput] = useState(false);
@@ -245,6 +246,7 @@ const TransactionOverview: React.FC<Props> = ({ data, loading }) => {
       }
       listItem={listOverview}
       loading={loading}
+      lastUpdated={lastUpdated}
     />
   );
 };

--- a/src/components/commons/Card/index.tsx
+++ b/src/components/commons/Card/index.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode } from "react";
 const CardContainer = styled(Box)`
   background-color: transparent;
   border-radius: var(--border-radius);
+  position: relative;
 `;
 
 const Header = styled(Box)`

--- a/src/components/commons/DetailHeader/index.tsx
+++ b/src/components/commons/DetailHeader/index.tsx
@@ -28,6 +28,7 @@ import {
   AllowSearchButton,
   StyledSelect,
   StyledMenuItem,
+  TimeDuration,
 } from "./styles";
 import { details, routers } from "../../../commons/routers";
 import Bookmark from "../BookmarkIcon";
@@ -37,12 +38,14 @@ import { useHistory } from "react-router-dom";
 import { SearchIcon } from "../../../commons/resources";
 import { BiChevronDown } from "react-icons/bi";
 import { numberWithCommas } from "../../../commons/utils/helper";
+import moment from "moment";
 
 interface DetailHeaderProps {
   type: Bookmark["type"];
   bookmarkData?: string;
   loading: boolean;
   title: number | string;
+  lastUpdated?: number;
   hash?: string;
   transactionStatus?: keyof typeof TransactionStatus;
   stakeKeyStatus?: StakeStatus;
@@ -58,7 +61,8 @@ interface DetailHeaderProps {
 }
 
 const DetailHeader: React.FC<DetailHeaderProps> = props => {
-  const { loading, listItem, epoch, type, title, hash, transactionStatus, bookmarkData, stakeKeyStatus } = props;
+  const { loading, listItem, epoch, type, title, hash, transactionStatus, bookmarkData, stakeKeyStatus, lastUpdated } =
+    props;
   const history = useHistory();
   const theme = useTheme();
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
@@ -133,6 +137,7 @@ const DetailHeader: React.FC<DetailHeaderProps> = props => {
               <SlotLeaderCopy text={hash} />
             </SlotLeader>
           )}
+          {!!lastUpdated && <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>}
         </Box>
         {epoch ? (
           <Box>

--- a/src/components/commons/DetailHeader/styles.ts
+++ b/src/components/commons/DetailHeader/styles.ts
@@ -24,6 +24,7 @@ export const BackText = styled("small")`
 export const HeaderContainer = styled(Box)`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 `;
 
 export const HeaderTitle = styled("h2")`
@@ -391,5 +392,11 @@ export const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
   justifyContent: "space-between",
   "&:hover": {
     backgroundColor: "rgba(67, 143, 104, 0.1)",
-  }
+  },
+}));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  marginBottom: 10,
 }));

--- a/src/components/commons/DetailView/DetailViewEpoch.tsx
+++ b/src/components/commons/DetailView/DetailViewEpoch.tsx
@@ -30,6 +30,7 @@ import {
   DetailLinkRight,
   ViewDetailScroll,
   ViewDetailHeader,
+  TimeDuration,
 } from "./styles";
 import useFetch from "../../../commons/hooks/useFetch";
 import { HiOutlineCube } from "react-icons/hi2";
@@ -42,6 +43,7 @@ import { API } from "../../../commons/utils/api";
 import { useSelector } from "react-redux";
 import ViewAllButton from "../ViewAllButton";
 import ADAicon from "../ADAIcon";
+import moment from "moment";
 
 type DetailViewEpochProps = {
   epochNo: number;
@@ -51,7 +53,7 @@ type DetailViewEpochProps = {
 
 const DetailViewEpoch: React.FC<DetailViewEpochProps> = ({ epochNo, handleClose, callback }) => {
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
-  const { data } = useFetch<IDataEpoch>(
+  const { data, lastUpdated } = useFetch<IDataEpoch>(
     `${API.EPOCH.DETAIL}/${epochNo}`,
     undefined,
     false,
@@ -145,6 +147,7 @@ const DetailViewEpoch: React.FC<DetailViewEpochProps> = ({ epochNo, handleClose,
     <ViewDetailDrawer anchor="right" open hideBackdrop variant="permanent">
       <ViewDetailHeader>
         <ViewAllButton tooltipTitle="View Detail" to={details.epoch(epochNo)} />
+        {!!lastUpdated && <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>}
         <CustomTooltip title="Close">
           <CloseButton onClick={handleClose}>
             <CgClose />

--- a/src/components/commons/DetailView/styles.ts
+++ b/src/components/commons/DetailView/styles.ts
@@ -484,3 +484,11 @@ export const ButtonModal = styled(Button)(({ theme }) => ({
     textDecoration: "underline",
   },
 }));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  textAlign: "left",
+  flex: 1,
+  padding: 10,
+}));

--- a/src/pages/BlockDetail/index.tsx
+++ b/src/pages/BlockDetail/index.tsx
@@ -11,7 +11,7 @@ import { REFRESH_TIMES } from "../../commons/utils/constants";
 const BlockDetail = () => {
   const { blockId } = useParams<{ blockId: string }>();
   const { state } = useLocation<{ data?: BlockDetail }>();
-  const { data, initialized, error } = useFetch<BlockDetail>(
+  const { data, initialized, error, lastUpdated } = useFetch<BlockDetail>(
     `${API.BLOCK.DETAIL}/${blockId}`,
     state?.data,
     false,
@@ -27,7 +27,7 @@ const BlockDetail = () => {
 
   return (
     <StyledContainer>
-      <BlockOverview data={data} loading={!initialized} />
+      <BlockOverview data={data} loading={!initialized} lastUpdated={lastUpdated} />
       <TransactionListsFull underline={true} url={`${API.BLOCK.DETAIL}/${blockId}/txs`} />
     </StyledContainer>
   );

--- a/src/pages/ContractList/index.tsx
+++ b/src/pages/ContractList/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../commons/utils/helper";
 import { details } from "../../commons/routers";
 import { AIcon } from "../../commons/resources";
-import { StyledContainer, StyledLink } from "./styles";
+import { StyledContainer, StyledLink, TimeDuration } from "./styles";
 import Table, { Column } from "../../components/commons/Table";
 import Card from "../../components/commons/Card";
 import CustomTooltip from "../../components/commons/CustomTooltip";
@@ -22,6 +22,7 @@ import { RootState } from "../../stores/types";
 import { API } from "../../commons/utils/api";
 import ADAicon from "../../components/commons/ADAIcon";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
 
 const Transactions: React.FC = () => {
   const { search } = useLocation();
@@ -99,7 +100,11 @@ const Transactions: React.FC = () => {
 
   return (
     <StyledContainer>
-      <Card title={"Contracts"} underline={false}>
+      <Card
+        title={"Contracts"}
+        underline={false}
+        extra={<TimeDuration>Last updated {moment(fetchData.lastUpdated).fromNow()}</TimeDuration>}
+      >
         <Table
           {...fetchData}
           columns={columns}

--- a/src/pages/ContractList/styles.ts
+++ b/src/pages/ContractList/styles.ts
@@ -9,3 +9,10 @@ export const StyledLink = styled(Link)`
   font-family: var(--font-family-text) !important;
   color: ${props => props.theme.palette.secondary.main} !important;
 `;
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  textAlign: "right", 
+  marginTop: "1rem",
+}));

--- a/src/pages/DelegationPools/index.tsx
+++ b/src/pages/DelegationPools/index.tsx
@@ -1,4 +1,3 @@
-import Card from "../../components/commons/Card";
 import OverViews from "../../components/DelegationPool/DelegationOverview";
 import { Horizon, StyledContainer } from "./styles";
 import DelegationLists from "../../components/DelegationPool/DelegationList";
@@ -14,9 +13,7 @@ const Delegations: React.FC<DelegationsProps> = () => {
   
   return (
     <StyledContainer>
-      <Card title="Delegation Pools Explorer">
-        <OverViews />
-      </Card>
+      <OverViews />
       <Horizon />
       <DelegationLists />
     </StyledContainer>

--- a/src/pages/EpochDetail/index.tsx
+++ b/src/pages/EpochDetail/index.tsx
@@ -12,7 +12,7 @@ const EpochDetail: React.FC = () => {
   const { epochId } = useParams<{ epochId: string }>();
   const { state } = useLocation<{ data?: IDataEpoch }>();
 
-  const { data, initialized, error } = useFetch<IDataEpoch>(
+  const { data, initialized, error, lastUpdated } = useFetch<IDataEpoch>(
     `${API.EPOCH.DETAIL}/${epochId}`,
     state?.data,
     false,
@@ -28,7 +28,7 @@ const EpochDetail: React.FC = () => {
 
   return (
     <StyledContainer>
-      <EpochOverview data={data} loading={!initialized} />
+      <EpochOverview data={data} loading={!initialized} lastUpdated={lastUpdated} />
       <EpochBlockList epochId={epochId} />
     </StyledContainer>
   );

--- a/src/pages/RegistrationPools/index.tsx
+++ b/src/pages/RegistrationPools/index.tsx
@@ -13,11 +13,12 @@ import {
 } from "../../commons/utils/helper";
 import CustomTooltip from "../../components/commons/CustomTooltip";
 import Table, { Column } from "../../components/commons/Table";
-import { RegistrationContainer, StakeKey, StyledLink, StyledTab, StyledTabs, TabLabel } from "./styles";
+import { RegistrationContainer, StakeKey, StyledLink, StyledTab, StyledTabs, TabLabel, TimeDuration } from "./styles";
 import { API } from "../../commons/utils/api";
 import NoRecord from "../../components/commons/NoRecord";
 import { Box } from "@mui/material";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
 
 enum POOL_TYPE {
   REGISTRATION = "registration",
@@ -142,6 +143,7 @@ const RegistrationPools = () => {
         <StyledTab value={POOL_TYPE.REGISTRATION} label={<TabLabel>Registration</TabLabel>} />
         <StyledTab value={POOL_TYPE.DEREREGISTRATION} label={<TabLabel>Deregistration</TabLabel>} />
       </StyledTabs>
+      <TimeDuration>Last updated {moment(fetchData.lastUpdated).fromNow()}</TimeDuration>
       <Box>
         <Table
           {...fetchData}

--- a/src/pages/RegistrationPools/styles.ts
+++ b/src/pages/RegistrationPools/styles.ts
@@ -13,6 +13,7 @@ export const StyledLink = styled(Link)`
 export const RegistrationContainer = styled(Container)`
   padding: 30px 0px 40px;
   text-align: left;
+  position: relative;
 `;
 
 export const StyledTabs = styled(Tabs)`
@@ -36,3 +37,23 @@ export const TabLabel = styled("h3")`
   text-transform: none;
   color: inherit;
 `;
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  textAlign: "right",
+  position: "absolute",
+  width: "max-content",
+  top: 60,
+  right: 24,
+  lineHeight: 1,
+  marginTop: "0.5rem",
+  [theme.breakpoints.down("sm")]: {
+    position: "relative",
+    width: "100%",
+    textAlign: "left",
+    marginTop: 10,
+    top: "unset",
+    right: "unset",
+  },
+}));

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -12,11 +12,12 @@ import CustomTooltip from "../../components/commons/CustomTooltip";
 import DetailViewStakeKey from "../../components/commons/DetailView/DetailViewStakeKey";
 import Table, { Column } from "../../components/commons/Table";
 import { setOnDetailView } from "../../stores/user";
-import { StyledContainer, StyledLink, StyledTab, StyledTabs, TabLabel } from "./styles";
+import { StyledContainer, StyledLink, StyledTab, StyledTabs, TabLabel, TimeDuration } from "./styles";
 import { API } from "../../commons/utils/api";
 import NoRecord from "../../components/commons/NoRecord";
 import SelectedIcon from "../../components/commons/SelectedIcon";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
 
 interface IStake {}
 
@@ -124,6 +125,7 @@ const Stake: React.FC<IStake> = () => {
           <StyledTab value={POOL_TYPE.REGISTRATION} label={<TabLabel>Registration</TabLabel>} />
           <StyledTab value={POOL_TYPE.DEREREGISTRATION} label={<TabLabel>Deregistration</TabLabel>} />
         </StyledTabs>
+        <TimeDuration>Last updated {moment(fetchData.lastUpdated).fromNow()}</TimeDuration>
         <Table
           {...fetchData}
           columns={columns}

--- a/src/pages/Stake/styles.ts
+++ b/src/pages/Stake/styles.ts
@@ -32,3 +32,23 @@ export const StyledLink = styled(Link)`
   font-family: var(--font-family-text) !important;
   color: ${props => props.theme.palette.secondary.main} !important;
 `;
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  textAlign: "right",
+  position: "absolute",
+  width: "max-content",
+  top: 30,
+  right: 24,
+  lineHeight: 1,
+  marginTop: "0.5rem",
+  [theme.breakpoints.down("sm")]: {
+    position: "relative",
+    width: "100%",
+    textAlign: "left",
+    marginTop: 15,
+    top: "unset",
+    right: "unset",
+  },
+}));

--- a/src/pages/StakeDetail/index.tsx
+++ b/src/pages/StakeDetail/index.tsx
@@ -13,7 +13,7 @@ const StakeDetail: React.FC = () => {
   const mainRef = useRef(document.querySelector("#main"));
   const { stakeId } = useParams<{ stakeId: string }>();
   const { state } = useLocation<{ data?: IStakeKeyDetail }>();
-  const { data, initialized, error } = useFetch<IStakeKeyDetail>(
+  const { data, initialized, error, lastUpdated } = useFetch<IStakeKeyDetail>(
     `${API.STAKE.DETAIL}/${stakeId}`,
     state?.data,
     false,
@@ -30,7 +30,7 @@ const StakeDetail: React.FC = () => {
 
   return (
     <StyledContainer>
-      <StakeKeyOverview data={data} loading={!initialized} />
+      <StakeKeyOverview data={data} loading={!initialized} lastUpdated={lastUpdated} />
       <StakeAnalytics />
       <StakeTab />
     </StyledContainer>

--- a/src/pages/Token/index.tsx
+++ b/src/pages/Token/index.tsx
@@ -10,12 +10,13 @@ import { formatDateTimeLocal, getPageInfo, getShortWallet, numberWithCommas } fr
 
 import DetailViewToken from "../../components/commons/DetailView/DetailViewToken";
 import useFetchList from "../../commons/hooks/useFetchList";
-import { AssetName, Logo, StyledContainer } from "./styles";
+import { AssetName, Logo, StyledContainer, TimeDuration } from "./styles";
 import CustomTooltip from "../../components/commons/CustomTooltip";
 import { useTheme } from "@mui/material";
 import { API } from "../../commons/utils/api";
 import SelectedIcon from "../../components/commons/SelectedIcon";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
 
 interface ITokenList {}
 
@@ -29,7 +30,7 @@ const Tokens: React.FC<ITokenList> = () => {
   const history = useHistory();
   const pageInfo = getPageInfo(search);
   const mainRef = useRef(document.querySelector("#main"));
-  const { data, ...fetchData } = useFetchList<ITokenOverview>(
+  const { data, lastUpdated, ...fetchData } = useFetchList<ITokenOverview>(
     API.TOKEN.LIST,
     { ...pageInfo, sort },
     false,
@@ -130,7 +131,7 @@ const Tokens: React.FC<ITokenList> = () => {
 
   return (
     <StyledContainer>
-      <Card title="Token List">
+      <Card title="Token List" extra={<TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>}>
         <Table
           {...fetchData}
           data={data}

--- a/src/pages/Token/styles.ts
+++ b/src/pages/Token/styles.ts
@@ -37,3 +37,9 @@ export const StyledSelect = styled(Select)`
     font-size: 20px;
   }
 `;
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  marginTop: "1rem",
+}));

--- a/src/pages/TopAddresses/index.tsx
+++ b/src/pages/TopAddresses/index.tsx
@@ -3,20 +3,21 @@ import useFetchList from "../../commons/hooks/useFetchList";
 import { Box, MenuItem, Select } from "@mui/material";
 import { formatADAFull, getShortWallet, numberWithCommas } from "../../commons/utils/helper";
 import { details } from "../../commons/routers";
-import { PerPage, StyledContainer, StyledLink } from "./styles";
+import { Actions, PageSize, PerPage, StyledContainer, StyledLink, TimeDuration } from "./styles";
 import Table, { Column } from "../../components/commons/Table";
 import Card from "../../components/commons/Card";
 import CustomTooltip from "../../components/commons/CustomTooltip";
 import { API } from "../../commons/utils/api";
 import ADAicon from "../../components/commons/ADAIcon";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
 
-interface Props {}
+const perPages = [10, 20, 50, 100];
 
-const TopAddresses: React.FC<Props> = () => {
+const TopAddresses: React.FC = () => {
   const [pageSize, setPageSize] = useState("50");
 
-  const { error, data, initialized, loading } = useFetchList<Contracts>(
+  const { error, data, initialized, loading, lastUpdated } = useFetchList<Contracts>(
     API.ADDRESS.TOP_ADDRESS,
     { page: 0, size: +pageSize },
     false,
@@ -72,26 +73,25 @@ const TopAddresses: React.FC<Props> = () => {
 
   return (
     <StyledContainer>
-      <Card
-        title={"Top addresses"}
-        underline={false}
-        extra={
-          <Box display="flex" alignItems="center">
+      <Card title={"Top addresses"} underline={false}>
+        <Actions>
+          <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>
+          <PageSize>
             <Select
               value={pageSize}
               onChange={event => setPageSize(event.target.value)}
               displayEmpty
               inputProps={{ "aria-label": "Without label" }}
             >
-              <MenuItem value={10}>10</MenuItem>
-              <MenuItem value={20}>20</MenuItem>
-              <MenuItem value={50}>50</MenuItem>
-              <MenuItem value={100}>100</MenuItem>
+              {perPages.map(item => (
+                <MenuItem key={item} value={item}>
+                  {item}
+                </MenuItem>
+              ))}
             </Select>
             <PerPage>Per page</PerPage>
-          </Box>
-        }
-      >
+          </PageSize>
+        </Actions>
         <Table data={data} error={error} loading={loading} initialized={initialized} columns={columns} />
       </Card>
     </StyledContainer>

--- a/src/pages/TopAddresses/styles.ts
+++ b/src/pages/TopAddresses/styles.ts
@@ -1,4 +1,4 @@
-import { styled, Container } from "@mui/material";
+import { styled, Container, Box } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const StyledContainer = styled(Container)`
@@ -10,6 +10,25 @@ export const StyledContainer = styled(Container)`
   }
 `;
 
+export const Actions = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginTop: -30,
+}));
+
+export const PageSize = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+}));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  marginRight: 15,
+}));
+
 export const StyledLink = styled(Link)`
   font-family: var(--font-family-text) !important;
   color: ${props => props.theme.palette.secondary.main} !important;
@@ -17,4 +36,4 @@ export const StyledLink = styled(Link)`
 
 export const PerPage = styled("div")`
   margin-left: 8px;
-`
+`;

--- a/src/pages/TopDelegators/index.tsx
+++ b/src/pages/TopDelegators/index.tsx
@@ -10,13 +10,16 @@ import Card from "../../components/commons/Card";
 import CustomTooltip from "../../components/commons/CustomTooltip";
 import Table from "../../components/commons/Table";
 import { Column } from "../../types/table";
-import { PerPage, StyledContainer, StyledLink } from "./styles";
+import { Actions, PageSize, PerPage, StyledContainer, StyledLink, TimeDuration } from "./styles";
 import { REFRESH_TIMES } from "../../commons/utils/constants";
+import moment from "moment";
+
+const perPages = [10, 20, 50, 100];
 
 const TopDelegators = () => {
   const history = useHistory();
   const [pageSize, setPageSize] = useState("50");
-  const { error, data, initialized, loading } = useFetchList<Contracts>(
+  const { error, data, initialized, loading, lastUpdated } = useFetchList<Contracts>(
     API.STAKE.TOP_DELEGATOR,
     { page: 0, size: +pageSize },
     false,
@@ -68,25 +71,25 @@ const TopDelegators = () => {
 
   return (
     <StyledContainer>
-      <Card
-        title="Top delegators"
-        extra={
-          <Box display="flex" alignItems="center">
+      <Card title="Top delegators">
+        <Actions>
+          <TimeDuration>Last updated {moment(lastUpdated).fromNow()}</TimeDuration>
+          <PageSize>
             <Select
               value={pageSize}
               onChange={event => setPageSize(event.target.value)}
               displayEmpty
               inputProps={{ "aria-label": "Without label" }}
             >
-              <MenuItem value={10}>10</MenuItem>
-              <MenuItem value={20}>20</MenuItem>
-              <MenuItem value={50}>50</MenuItem>
-              <MenuItem value={100}>100</MenuItem>
+              {perPages.map(item => (
+                <MenuItem key={item} value={item}>
+                  {item}
+                </MenuItem>
+              ))}
             </Select>
             <PerPage>Per page</PerPage>
-          </Box>
-        }
-      >
+          </PageSize>
+        </Actions>
         <Table
           onClickRow={(_, r) => history.push(details.stake(r.stakeKey))}
           data={data}

--- a/src/pages/TopDelegators/styles.ts
+++ b/src/pages/TopDelegators/styles.ts
@@ -1,4 +1,4 @@
-import { Container, styled } from "@mui/material";
+import { Box, Container, styled } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const StyledContainer = styled(Container)`
@@ -17,4 +17,23 @@ export const StyledLink = styled(Link)`
 
 export const PerPage = styled("div")`
   margin-left: 8px;
-`
+`;
+
+export const Actions = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginTop: -30,
+}));
+
+export const PageSize = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+}));
+
+export const TimeDuration = styled("small")(({ theme }) => ({
+  color: theme.palette.grey[400],
+  display: "block",
+  marginRight: 15,
+}));

--- a/src/pages/TransactionDetail/index.tsx
+++ b/src/pages/TransactionDetail/index.tsx
@@ -16,11 +16,11 @@ const StyledContainer = styled(Container)`
 const Transaction: React.FC = () => {
   const { trxHash } = useParams<{ trxHash: string }>();
   const { state } = useLocation<{ data?: Transaction }>();
-  const { data, initialized, error } = useFetch<Transaction>(
+  const { data, initialized, error, lastUpdated } = useFetch<Transaction>(
     `${API.TRANSACTION.DETAIL}/${trxHash}`,
     state?.data,
     false,
-    REFRESH_TIMES.EPOCH_DETAIL
+    REFRESH_TIMES.TRANSACTION_DETAIL
   );
 
   useEffect(() => {
@@ -32,7 +32,7 @@ const Transaction: React.FC = () => {
 
   return (
     <StyledContainer>
-      <TransactionOverview data={data} loading={!initialized} />
+      <TransactionOverview data={data} loading={!initialized} lastUpdated={lastUpdated} />
       <Box>
         {!initialized ? (
           <Card>


### PR DESCRIPTION
## Description

Add last updated message for auto refresh screens

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-408](https://cardanofoundation.atlassian.net/browse/MET-408)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

Don't have last updated message

##### _After_

Add last updated message after auto refresh:

 - Latest Transactions
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/1d14f174-d2ae-4c3f-af0c-aeb6931feca4)

 - Top Delegation Pools
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/458fa9af-dcf7-4a5c-87df-79c03eae311e)

 - Epoch detail
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/e6d7fc88-18da-4f15-b054-44f4fd87472e)

 - Epoch tab view (when click item in list)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/ef93c9a9-c62d-4915-875d-809cf08de1cb)

 - Block detail
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/92230fbe-5eb8-4c4b-8d60-d47e8507b185)

 - Transaction detail
 ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/9493618d-4b9b-4163-83ec-ea7c1cd591a9)

 - Token list
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/4f67e4bc-8a90-461e-8942-9699355dceb2)


 - Top address
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/05282423-999e-44a8-8363-06089c06830c)

 - Contracts
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/29d83f14-3047-4120-97cf-96ae90fbc99a)
 
  - Delegation Pools
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/a1b4eeb9-c2f6-430f-8724-6a8dbf753958)

 - Stake key registration
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/bb7fc3d1-e650-4430-8670-a20a7df9e6d3)

 - Pool registration
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/6fd49faa-7f42-4476-ae69-6e9564b73ce8)

 - Top Delegators
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/04af0cb8-26ed-478b-b85f-28725f987a79)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

Same Chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

No apply

[MET-408]: https://cardanofoundation.atlassian.net/browse/MET-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ