### PR TITLE
fix: incorrect progress in block and transaction detail

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+import { useSelector } from "react-redux";
 
 import {
   timeIconUrl,
@@ -23,6 +24,8 @@ interface BlockOverviewProps {
 }
 
 const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdated }) => {
+  const { currentEpoch } = useSelector(({ system }: RootState) => system);
+
   const renderConfirmationTag = () => {
     if (data && data.confirmation) {
       if (data.confirmation <= 2) {
@@ -132,7 +135,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
       epoch={
         data && {
           no: data.epochNo,
-          slot: data.epochSlotNo
+          slot: currentEpoch?.no === data.epochNo ? data.epochSlotNo : MAX_SLOT_EPOCH
         }
       }
     />

--- a/src/components/commons/DetailHeader/index.tsx
+++ b/src/components/commons/DetailHeader/index.tsx
@@ -187,13 +187,16 @@ const DetailHeader: React.FC<DetailHeaderProps> = (props) => {
               size={100}
               pathWidth={8}
               percent={
-                currentEpoch && (epoch?.no || 0) === currentEpoch?.no
-                  ? ((moment(formatDateTimeLocal(epoch?.endTime || "")).diff(moment()) > 0
-                      ? epoch?.slot
-                      : MAX_SLOT_EPOCH) /
-                      MAX_SLOT_EPOCH) *
-                    100
-                  : 100
+                type === "EPOCH"
+                  ? currentEpoch && (epoch?.no || 0) === currentEpoch?.no
+                    ? ((moment(formatDateTimeLocal(epoch?.endTime || "")).diff(moment()) > 0 &&
+                      epoch?.slot < MAX_SLOT_EPOCH
+                        ? epoch?.slot
+                        : MAX_SLOT_EPOCH) /
+                        MAX_SLOT_EPOCH) *
+                      100
+                    : 100
+                  : (epoch?.slot / MAX_SLOT_EPOCH) * 100
               }
             >
               <EpochNumber is_epoch={+(type === "EPOCH")} to={details.epoch(epoch.no || 0)}>


### PR DESCRIPTION
## Description

current epoch is 416 but in block details and transaction details progress cycle is showing at 100%

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
**Block detail**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/7fdadc55-d9e9-4aa1-8958-3c31af7a7b82)

**Transaction detail**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/04b235b7-45ad-4d4c-b966-f0888785cdc7)

##### _After_

**Block detail**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/4d7c0add-3738-47f9-9c7e-77cbee528b50)

**Transaction detail**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/926300db-2416-4144-8b93-3cd7b759a9b6)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)