### PR TITLE
fix: hide scroll bar in popup operator

### DIFF
--- a/src/components/StakingLifeCycle/SPOLifecycle/OperatorRewards/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/OperatorRewards/index.tsx
@@ -9,7 +9,7 @@ import { details } from "src/commons/routers";
 import { formatADAFull, getShortWallet } from "src/commons/utils/helper";
 import useFetch from "src/commons/hooks/useFetch";
 import { API } from "src/commons/utils/api";
-import StyledModal from "src/components/commons/StyledModal";
+import CustomModal from "src/components/commons/CustomModal";
 import Table, { Column } from "src/components/commons/Table";
 import useFetchList from "src/commons/hooks/useFetchList";
 import ADAicon from "src/components/commons/ADAIcon";
@@ -17,7 +17,6 @@ import CardanoSystem from "src/components/commons/CardanoSystem";
 import SPOHolder from "src/components/commons/SPOHolder";
 import DrawPath from "src/components/commons/DrawPath";
 import { LineArrowItem } from "src/components/commons/LineArrow";
-import { WrappModalScrollBar } from "src/components/commons/Table/styles";
 
 import { StyledLink, DrawContainer, ADAOperator, ADATitle, ADAAmount, StyledEpoch } from "./styles";
 
@@ -66,13 +65,13 @@ const OperatorReward = () => {
         <DrawPath paths={paths} />
       </DrawContainer>
 
-      <OperatorRewardModal open={openModal} handleCloseModal={() => setOpenModal(false)} />
+      <OperatorRewardModal open={openModal} onClose={() => setOpenModal(false)} />
     </Box>
   );
 };
 export default OperatorReward;
 
-const OperatorRewardModal = ({ ...props }: { open: boolean; handleCloseModal: () => void }) => {
+const OperatorRewardModal = ({ ...props }: { open: boolean; onClose: () => void }) => {
   const { poolId = "" } = useParams<{ poolId: string }>();
   const [sort, setSort] = useState<string>("");
   const [{ page, size }, setPagination] = useState<{ page: number; size: number }>({ page: 0, size: 50 });
@@ -116,24 +115,20 @@ const OperatorRewardModal = ({ ...props }: { open: boolean; handleCloseModal: ()
     }
   ];
   return (
-    <StyledModal width={600} {...props} title="Operator rewards received">
-      <Box>
-        <WrappModalScrollBar>
-          <StyledTable
-            {...fetchData}
-            columns={columns}
-            total={{ title: "Total Epochs", count: fetchData.total }}
-            maxHeight={"60vh"}
-            pagination={{
-              page,
-              size,
-              total: fetchData.total,
-              onChange: (page, size) => setPagination({ page: page - 1, size })
-            }}
-          />
-        </WrappModalScrollBar>
-      </Box>
-    </StyledModal>
+    <CustomModal {...props} title="Operator rewards received">
+      <StyledTable
+        {...fetchData}
+        columns={columns}
+        total={{ title: "Total Epochs", count: fetchData.total }}
+        maxHeight={"60vh"}
+        pagination={{
+          page,
+          size,
+          total: fetchData.total,
+          onChange: (page, size) => setPagination({ page: page - 1, size })
+        }}
+      />
+    </CustomModal>
   );
 };
 

--- a/src/components/StakingLifeCycle/SPOLifecycle/OperatorRewards/styles.ts
+++ b/src/components/StakingLifeCycle/SPOLifecycle/OperatorRewards/styles.ts
@@ -48,3 +48,4 @@ export const ADATitle = styled(Box)(() => ({
 export const ADAAmount = styled(Box)`
   color: ${(props) => props.theme.palette.green[600]} !important;
 `;
+

--- a/src/components/commons/CustomModal/index.tsx
+++ b/src/components/commons/CustomModal/index.tsx
@@ -15,9 +15,10 @@ interface Props extends Omit<BoxProps, "title"> {
 }
 
 export const CustomModal: React.FC<Props> = forwardRef((props, ref) => {
-  const { open, onClose, closeButton, closeButtonProps, title, titleProps, children, ...contentProps } = props;
+  const { open, onClose, closeButton, closeButtonProps, title, titleProps, modalProps, children, ...contentProps } =
+    props;
   return (
-    <Modal open={open}>
+    <Modal open={open} {...modalProps}>
       <ModalContainer>
         {closeButton || (
           <CloseButton {...closeButtonProps} onClick={onClose} data-testid="close-modal-button">


### PR DESCRIPTION


## Description

Hide scroll bar in popup operator

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)