### PR TITLE
bugfix/MET-615-responsive-text-in-line-breaks

### DIFF
--- a/src/components/commons/Card/index.tsx
+++ b/src/components/commons/Card/index.tsx
@@ -18,6 +18,7 @@ const Title = styled("h2")<{ underline: number; marginTitle?: string }>`
   text-align: left;
   padding-bottom: 8px;
   position: relative;
+  width: max-content;
   ${(props) => (props.underline ? `font-size: 1.25rem;` : "")};
   margin: ${({ marginTitle }) => (marginTitle ? marginTitle : "unset")};
   &::after {


### PR DESCRIPTION


## Description

Text in line breaks

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
#### Before
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/cad1d8c9-e685-4feb-aa96-70b67f7a1521)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/aecc6045-4e9e-4c89-ab5b-7e94dfb89217)

#### Safari
##### _Before_

Same chrome

##### _After_

Same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/d0300da9-14b3-43b0-9a82-2a8fadb7715c)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/edbc87d8-ed9a-4d3e-a1b3-787dd40ad4f5)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ