### PR TITLE
Fix: MET-615 Ui Tabular Overview

### DIFF
--- a/src/components/StakingLifeCycle/SPOLifecycle/Tablular/TabularOverview/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/Tablular/TabularOverview/index.tsx
@@ -109,7 +109,9 @@ const TabularOverview: React.FC = () => {
           mainIcon={<StatusIC />}
           value={
             <WrapStatus>
-              <CardValue noWhiteSpace={1} color={STATUS[data?.status ?? "ACTIVE"][1]}>{STATUS[data?.status ?? "ACTIVE"][0] + ": "}</CardValue>
+              <CardValue sx={{
+                whiteSpace: "pre",
+              }} color={STATUS[data?.status ?? "ACTIVE"][1]}>{STATUS[data?.status ?? "ACTIVE"][0] + ": "}</CardValue>
               <ClickAbleLink to={details.epoch(data?.epochNo)}>Epoch {data?.epochNo}</ClickAbleLink>
             </WrapStatus>
           }

--- a/src/components/StakingLifeCycle/SPOLifecycle/Tablular/TabularOverview/styles.ts
+++ b/src/components/StakingLifeCycle/SPOLifecycle/Tablular/TabularOverview/styles.ts
@@ -35,9 +35,9 @@ export const CardTitle = styled(Typography)(({ theme }) => ({
   marginBottom: 4
 }));
 
-export const CardValue = styled(Typography)<{ color?: string, noWhiteSpace?: number }>(({ theme, ...rest }) => ({
+export const CardValue = styled(Typography)<{ color?: string }>(({ theme, ...rest }) => ({
   overflowWrap: "anywhere",
-  whiteSpace: rest.noWhiteSpace ? "pre" : "break-spaces",
+  whiteSpace: "break-spaces",
   fontWeight: theme.typography.fontWeightBold,
   fontSize: 16,
   color: rest.color ? rest.color : theme.palette.grey[700]


### PR DESCRIPTION
## Description

Fix Ui bug, sign in screen redirect to previous page when successful and can use key "enter" when login

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/a3ba050b-ef16-4f06-a5bc-b3882037de8a)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/d721aec3-8630-451e-83e9-d75771d2f9c7)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ