### PR TITLE
fix: MET-615-responsive-wrong-format-delegated-to

### DIFF
--- a/src/components/TabularView/TabularOverview/styles.ts
+++ b/src/components/TabularView/TabularOverview/styles.ts
@@ -96,13 +96,7 @@ export const CardValue = styled(Typography)(({ theme }) => ({
 export const CardValueDelegating = styled(CardValue)(({ theme }) => ({
   width: "calc(100% - 79px)",
   [theme.breakpoints.down("lg")]: {
-    width: "calc(100% - 100px)"
-  },
-  [theme.breakpoints.down("md")]: {
-    width: "calc(100% - 130px)"
-  },
-  [theme.breakpoints.down("sm")]: {
-    width: "calc(100% - 60px)"
+    width: "calc(100% - 10px)"
   }
 }));
 export const BoxStyled = styled(CardValue)(({ theme }) => ({
@@ -113,8 +107,7 @@ export const BoxStyled = styled(CardValue)(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {
     fontSize: 20,
     lineHeight: "23px",
-    whiteSpace: "wrap",
-    wordBreak: "break-all"
+    whiteSpace: "nowrap"
   }
 }));
 export const StyledBoxDelegating = styled(Link)(() => ({


### PR DESCRIPTION


## Description

 Wrong format delegated to

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)