### PR TITLE
fix: MET-241 show tooltip when protocol change not trx hash

### DIFF
--- a/src/pages/ProtocolParameter/index.tsx
+++ b/src/pages/ProtocolParameter/index.tsx
@@ -290,7 +290,7 @@ export const ProtocolParameterHistory = () => {
               : "#"
           }
         >
-          {r[t]?.status === "ADDED" ? (
+          {r[t]?.status === "ADDED" || (r[t]?.status === "UPDATED" && !r[t]?.transactionHash) ? (
             <CustomTooltip title="No transaction">
               <Box>{r[t] ? (r[t]?.value ? r[t]?.value : r[t]?.value === 0 ? 0 : "") : ""}</Box>
             </CustomTooltip>


### PR DESCRIPTION
## Description

show tooltip when protocol change not trx hash

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-241)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/7555b569-8486-4316-b3cb-5ef4a02b17c7)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/13286d0e-6d82-4b46-82d7-87f0699ea21c)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)