### PR TITLE
bugfix: can't add props for Card common

### DIFF
--- a/src/components/StakeDetail/StakeAnalytics/index.tsx
+++ b/src/components/StakeDetail/StakeAnalytics/index.tsx
@@ -85,7 +85,7 @@ const StakeAnalytics: React.FC = () => {
       )
     : { epoch: 0, value: 0 };
   return (
-    <Card title="Analytics" pt={5}>
+    <Card title="Analytics">
       <Wrapper container columns={24} spacing="35px">
         <Grid item xs={24} lg={18}>
           <Grid spacing={2} container alignItems="center" justifyContent={"space-between"}>

--- a/src/components/TokenDetail/TokenAnalytics/index.tsx
+++ b/src/components/TokenDetail/TokenAnalytics/index.tsx
@@ -63,7 +63,7 @@ const AddressAnalytics: React.FC = () => {
 
   return (
     <Box pt={isMobile ? 0 : "20px"}>
-      <Card title="Analytics" py={4}>
+      <Card title="Analytics">
         <Wrapper container columns={24} spacing="35px">
           <Grid item xs={24} lg={18}>
             <Grid spacing={2} container alignItems="center" justifyContent={"space-between"}>

--- a/src/components/commons/Card/index.tsx
+++ b/src/components/commons/Card/index.tsx
@@ -1,5 +1,4 @@
-import { Box, styled } from "@mui/material";
-import { BoxProps } from "@mui/system";
+import { Box, styled, BoxProps } from "@mui/material";
 import React, { ReactNode } from "react";
 
 const CardContainer = styled(Box)`
@@ -44,9 +43,9 @@ interface CardProps extends Omit<BoxProps, "title"> {
   marginTitle?: string;
 }
 
-const Card: React.FC<CardProps> = ({ title, marginTitle, children, underline = false, extra }) => {
+const Card: React.FC<CardProps> = ({ title, marginTitle, children, underline = false, extra, ...props }) => {
   return (
-    <CardContainer>
+    <CardContainer {...props}>
       <Header>
         {title ? (
           <Title marginTitle={marginTitle} underline={underline ? 1 : 0}>

--- a/src/pages/ProtocolParameter/index.tsx
+++ b/src/pages/ProtocolParameter/index.tsx
@@ -144,7 +144,7 @@ const ProtocolParameter: React.FC = () => {
       )}
       {showHistory && <ProtocolParameterHistory />}
       {!showHistory && (
-        <Card marginTitle="0px" title={"Protocol parameters"} textAlign={"left"}>
+        <Card marginTitle="0px" title={"Protocol parameters"}>
           <Box pt={2}>
             <>
               <Box pb={"30px"} borderBottom={`1px solid ${alpha(theme.palette.common.black, 0.1)}`}>

--- a/src/pages/TopAddresses/index.tsx
+++ b/src/pages/TopAddresses/index.tsx
@@ -75,7 +75,7 @@ const TopAddresses = () => {
 
   return (
     <StyledContainer>
-      <Card title={"Top addresses"} underline={false}>
+      <Card title={"Top addresses"}>
         <Actions>
           <TimeDuration>
             <FormNowMessage time={lastUpdated} />


### PR DESCRIPTION
## Description

Can't add props for Card common because missing pass default BoxProps to CardContainer.
This update for add data-testid (Unit test) or other attribute (in future) in the components use Card common.
For detail, please look at the changes of src\components\commons\Card\index.tsx file.
New update:
  - Pass all default props BoxProps to CardContainer.
  - Remove default props in component use Card because it is invalid with this update.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No Jira ticket

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

No change

##### _After_

No change

#### Safari
##### _Before_

No change

##### _After_

No change

#### Responsive
##### _Before_

No change

##### _After_

No change