### PR TITLE
test: Fix conflict bugfix/met 615 epoch block detail header responsive

### DIFF
--- a/src/components/commons/DetailHeader/index.tsx
+++ b/src/components/commons/DetailHeader/index.tsx
@@ -330,7 +330,7 @@ const BufferList = memo(({ numberOfItems, wide, children }: BufferListProps) => 
   // numberOfRow in tablet screen is 2, numberOfBuffer is 1;
   const numberOfBuffer = numberOfRow - ((numberOfItems - bufferWide) % numberOfRow || numberOfRow);
 
-  if (isLaptop || numberOfItems > 6)
+  if ((isLaptop && numberOfItems > 4) || numberOfItems > 6)
     return (
       <>
         {new Array(numberOfBuffer).fill(0).map((_, index) => {

--- a/src/components/commons/DetailHeader/styles.ts
+++ b/src/components/commons/DetailHeader/styles.ts
@@ -322,12 +322,12 @@ export const CardItem = styled(Grid)<{ length: number; wide?: number }>(({ theme
     paddingBottom: 20,
     borderBottomWidth: 1,
     borderLeftWidth: 1,
-    ":nth-of-type(3n + 1)": {
+    [`:nth-of-type(${length === 4 ? 4 : 3}n + 1)`]: {
       borderLeftWidth: 0,
       paddingLeft: 0
     },
-    ":nth-last-of-type(-n + 3)": {
-      ":nth-of-type(3n + 1)": {
+    [`:nth-last-of-type(-n + ${length === 4 ? 4 : 3})`]: {
+      [`:nth-of-type(${length === 4 ? 4 : 3}n + 1)`]: {
         borderBottomWidth: 0,
         "&~div": {
           borderBottomWidth: 0,


### PR DESCRIPTION
## Description

Fix bug miss border and gap in screen epoch, block detail.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

|   Before   |  After  |
:-------------------------:|:-------------------------:
|  ![Screenshot_18](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/1d250bf8-3106-438c-b8b2-0b79544a0225)  |  ![Screenshot_19](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/deaaa780-e914-463b-9265-0b81f17c115d)  |
 
|   Before   |  After  |
:-------------------------:|:-------------------------:
|  ![Screenshot_20](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/c1324582-1204-440c-ad40-46f897390adf)  |  ![Screenshot_21](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/466e1129-0913-4b08-b7d5-65cfeed181c6)  |
 

#### Safari
##### _Before_

Same chrome

##### _After_

Same chrome

#### Responsive
##### _Before_

No change

##### _After_

No change

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ