### PR TITLE
Fix: MET-615 trim signin signup field and add sort by time report page

### DIFF
--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/DelegationTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/DelegationTab.tsx
@@ -24,6 +24,7 @@ const DelegationTab = () => {
   const { search } = useLocation();
   const history = useHistory();
   const [pageInfo, setPageInfo] = useState(() => getPageInfo(search));
+  const [sort, setSort] = useState<string>("");
   const [params] = useState<FilterParams>({
     fromDate: undefined,
     sort: undefined,
@@ -32,7 +33,8 @@ const DelegationTab = () => {
   });
   const fetchData = useFetchList<DelegationItem>(reportId ? API.REPORT.SREPORT_DETAIL_DELEGATIONS(reportId) : "", {
     ...pageInfo,
-    ...params
+    ...params,
+    sort: sort || params.sort
   });
   const { total } = fetchData;
   const columns: Column<DelegationItem>[] = [
@@ -50,7 +52,10 @@ const DelegationTab = () => {
       title: "Timestamp",
       key: "time",
       minWidth: "120px",
-      render: (r) => formatDateTimeLocal(r.time)
+      render: (r) => formatDateTimeLocal(r.time),
+      sort: ({ columnKey, sortValue }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
+      }
     },
     {
       title: "Fees",

--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/DeregistrationTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/DeregistrationTab.tsx
@@ -13,59 +13,64 @@ import { API } from "src/commons/utils/api";
 
 import { AdaValue } from "./StakingRegistrationTab";
 
-const columns: Column<DeregistrationItem>[] = [
-  {
-    title: "Transaction Hash",
-    key: "hash",
-    minWidth: "120px",
-    render: (r) => (
-      <CustomTooltip title={r.txHash}>
-        <StyledLink to={details.transaction(r.txHash)}>{getShortHash(r.txHash)}</StyledLink>
-      </CustomTooltip>
-    )
-  },
-  {
-    title: "Timestamp",
-    key: "time",
-    minWidth: "120px",
-    render: (r) => formatDateTimeLocal(r.time)
-  },
-  {
-    title: (
-      <>
-        <Box>ADA Amount</Box>
-        <TableSubTitle>Hold/Fees</TableSubTitle>
-      </>
-    ),
-    key: "block",
-    minWidth: "120px",
-    render: (r) => (
-      <Box>
-        <AdaValue value={-r.deposit - r.fee} />
-        <TableSubTitle>
-          <Box display="flex" mt={1} alignItems="center" lineHeight="1">
-            <AdaValue value={-r.deposit} gap="3px" fontSize="12px" />
-            <Box mx="3px">/</Box>
-            <AdaValue value={r.fee} gap="3px" fontSize="12px" />
-          </Box>
-        </TableSubTitle>
-      </Box>
-    )
-  }
-];
 
 const DeregistrationTab = () => {
   const { reportId } = useParams<{ reportId: string }>();
   const { search } = useLocation();
   const history = useHistory();
   const [pageInfo, setPageInfo] = useState(() => getPageInfo(search));
+  const [sort, setSort] = useState<string>("");
 
   const fetchData = useFetchList<DeregistrationItem>(
     reportId ? API.REPORT.SREPORT_DETAIL_DEGEGISTRATIONS(reportId) : "",
     {
-      ...pageInfo
+      ...pageInfo,
+      sort
     }
   );
+  const columns: Column<DeregistrationItem>[] = [
+    {
+      title: "Transaction Hash",
+      key: "hash",
+      minWidth: "120px",
+      render: (r) => (
+        <CustomTooltip title={r.txHash}>
+          <StyledLink to={details.transaction(r.txHash)}>{getShortHash(r.txHash)}</StyledLink>
+        </CustomTooltip>
+      )
+    },
+    {
+      title: "Timestamp",
+      key: "time",
+      minWidth: "120px",
+      render: (r) => formatDateTimeLocal(r.time),
+      sort: ({ columnKey, sortValue }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
+      }
+    },
+    {
+      title: (
+        <>
+          <Box>ADA Amount</Box>
+          <TableSubTitle>Hold/Fees</TableSubTitle>
+        </>
+      ),
+      key: "block",
+      minWidth: "120px",
+      render: (r) => (
+        <Box>
+          <AdaValue value={-r.deposit - r.fee} />
+          <TableSubTitle>
+            <Box display="flex" mt={1} alignItems="center" lineHeight="1">
+              <AdaValue value={-r.deposit} gap="3px" fontSize="12px" />
+              <Box mx="3px">/</Box>
+              <AdaValue value={r.fee} gap="3px" fontSize="12px" />
+            </Box>
+          </TableSubTitle>
+        </Box>
+      )
+    }
+  ];
 
   return (
     <Table

--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/RewardsDistributionTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/RewardsDistributionTab.tsx
@@ -12,32 +12,13 @@ import { FilterParams } from "src/components/StackingFilter";
 import { WrapFilterDescription } from "src/components/StakingLifeCycle/DelegatorLifecycle/Withdraw/RecentWithdraws/styles";
 import { API } from "src/commons/utils/api";
 
-const columns: Column<RewardDistributionItem>[] = [
-  {
-    title: "Rewards Paid",
-    key: "paid",
-    minWidth: "120px",
-    render: (r) => <AdaValue value={r.amount} />
-  },
-  {
-    title: "Timestamp",
-    key: "time",
-    minWidth: "120px",
-    render: (r) => formatDateTimeLocal(r.time)
-  },
-  {
-    title: "Epoch",
-    key: "epoch",
-    minWidth: "120px",
-    render: (r) => <StyledLink to={details.epoch(r.epoch)}>{r.epoch}</StyledLink>
-  }
-];
 
 const RewardsDistributionTab = () => {
   const { reportId } = useParams<{ reportId: string }>();
   const { search } = useLocation();
   const history = useHistory();
   const [pageInfo, setPageInfo] = useState(() => getPageInfo(search));
+  const [sort, setSort] = useState<string>("");
   const [params] = useState<FilterParams>({
     fromDate: undefined,
     sort: undefined,
@@ -46,10 +27,33 @@ const RewardsDistributionTab = () => {
   });
   const fetchData = useFetchList<RewardDistributionItem>(reportId ? API.REPORT.SREPORT_DETAIL_REWARDS(reportId) : "", {
     ...pageInfo,
-    ...params
+    ...params,
+    sort: sort || params.sort
   });
   const { total } = fetchData;
-
+  const columns: Column<RewardDistributionItem>[] = [
+    {
+      title: "Rewards Paid",
+      key: "paid",
+      minWidth: "120px",
+      render: (r) => <AdaValue value={r.amount} />
+    },
+    {
+      title: "Timestamp",
+      key: "time",
+      minWidth: "120px",
+      render: (r) => formatDateTimeLocal(r.time),
+      sort: ({  sortValue }) => {
+        sortValue ? setSort(`id,${sortValue}`) : setSort("");
+      }
+    },
+    {
+      title: "Epoch",
+      key: "epoch",
+      minWidth: "120px",
+      render: (r) => <StyledLink to={details.epoch(r.epoch)}>{r.epoch}</StyledLink>
+    }
+  ];
   return (
     <>
       <Box display="flex" alignItems="center" justifyContent="space-between" mt={3}>

--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/StakingRegistrationTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/StakingRegistrationTab.tsx
@@ -34,10 +34,12 @@ const StakingRegistrationTab = () => {
   const [openModal, setOpenModal] = useState(false);
   const { search } = useLocation();
   const history = useHistory();
+  const [sort, setSort] = useState<string>("");
   const [pageInfo, setPageInfo] = useState(getPageInfo(search));
   const { stakeKey } = useContext(StakingDetailContext);
   const fetchData = useFetchList<RegistrationItem>(reportId ? API.REPORT.SREPORT_DETAIL_REGISTRATIONS(reportId) : "", {
-    ...pageInfo
+    ...pageInfo,
+    sort
   });
 
   const columns: Column<RegistrationItem>[] = [
@@ -55,6 +57,9 @@ const StakingRegistrationTab = () => {
       title: "Timestamp",
       key: "time",
       minWidth: "120px",
+      sort: ({ columnKey, sortValue }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
+      },
       render: (r) => formatDateTimeLocal(r.time)
     },
     {

--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/WithdrawalHistoryTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/WithdrawalHistoryTab.tsx
@@ -14,52 +14,13 @@ import { WrapFilterDescription } from "src/components/StakingLifeCycle/Delegator
 import { details } from "src/commons/routers";
 import { AdaValue } from "src/components/TabularView/StakeTab/Tabs/StakeRegistrationTab";
 
-const columns: Column<WithdrawItem>[] = [
-  {
-    title: "Transaction Hash",
-    key: "hash",
-    minWidth: "120px",
-    render: (r) => (
-      <CustomTooltip title={r.txHash}>
-        <StyledLink to={details.transaction(r.txHash)}>{getShortHash(r.txHash)}</StyledLink>
-      </CustomTooltip>
-    )
-  },
-  {
-    title: "Timestamp",
-    key: "time",
-    minWidth: "120px",
-    render: (r) => formatDateTimeLocal(r.time)
-  },
-  {
-    title: (
-      <>
-        <Box>Net Amount</Box>
-        <TableSubTitle>Withdrawn/Fees</TableSubTitle>
-      </>
-    ),
-    key: "epoch",
-    minWidth: "120px",
-    render: (r) => (
-      <Box>
-        <AdaValue value={r.value + r.fee} />
-        <TableSubTitle>
-          <Box display="flex" mt={1} alignItems="center" lineHeight="1">
-            <AdaValue value={r.value} gap="3px" fontSize="12px" />
-            <Box mx="3px">/</Box>
-            <AdaValue value={r.fee} gap="3px" fontSize="12px" />
-          </Box>
-        </TableSubTitle>
-      </Box>
-    )
-  }
-];
 
 const WithdrawalHistoryTab = () => {
   const { reportId } = useParams<{ reportId: string }>();
   const { search } = useLocation();
   const history = useHistory();
   const [pageInfo, setPageInfo] = useState(() => getPageInfo(search));
+  const [sort, setSort] = useState<string>("");
   const [params] = useState<FilterParams>({
     fromDate: undefined,
     sort: undefined,
@@ -70,10 +31,54 @@ const WithdrawalHistoryTab = () => {
     reportId ? API.REPORT.SREPORT_DETAIL_WITHDRAWALS(reportId) : "",
     {
       ...pageInfo,
-      ...params
+      ...params,
+      sort: sort || params.sort
     }
   );
   const { total } = fetchData;
+  const columns: Column<WithdrawItem>[] = [
+    {
+      title: "Transaction Hash",
+      key: "hash",
+      minWidth: "120px",
+      render: (r) => (
+        <CustomTooltip title={r.txHash}>
+          <StyledLink to={details.transaction(r.txHash)}>{getShortHash(r.txHash)}</StyledLink>
+        </CustomTooltip>
+      )
+    },
+    {
+      title: "Timestamp",
+      key: "time",
+      minWidth: "120px",
+      render: (r) => formatDateTimeLocal(r.time),
+      sort: ({ columnKey, sortValue }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
+      }
+    },
+    {
+      title: (
+        <>
+          <Box>Net Amount</Box>
+          <TableSubTitle>Withdrawn/Fees</TableSubTitle>
+        </>
+      ),
+      key: "epoch",
+      minWidth: "120px",
+      render: (r) => (
+        <Box>
+          <AdaValue value={r.value + r.fee} />
+          <TableSubTitle>
+            <Box display="flex" mt={1} alignItems="center" lineHeight="1">
+              <AdaValue value={r.value} gap="3px" fontSize="12px" />
+              <Box mx="3px">/</Box>
+              <AdaValue value={r.fee} gap="3px" fontSize="12px" />
+            </Box>
+          </TableSubTitle>
+        </Box>
+      )
+    }
+  ];
 
   return (
     <>

--- a/src/pages/ForgotPassword/index.tsx
+++ b/src/pages/ForgotPassword/index.tsx
@@ -73,7 +73,7 @@ export default function ForgotPassword() {
     if (error) setError(false);
     setFormData({
       name: event.target.name,
-      value: event.target.value,
+      value: event.target.value.trim(),
       touched: true
     });
   };

--- a/src/pages/RegistrationPools/index.tsx
+++ b/src/pages/RegistrationPools/index.tsx
@@ -118,7 +118,7 @@ const RegistrationPools = () => {
       }
     },
     {
-      title: "Fees",
+      title: "Fee",
       key: poolType === POOL_TYPE.REGISTRATION ? "margin" : "pu.margin",
       render: (pool) => formatPercent(pool.margin),
       sort: ({ columnKey, sortValue }) => {

--- a/src/pages/ResetPassword/index.tsx
+++ b/src/pages/ResetPassword/index.tsx
@@ -113,7 +113,7 @@ export default function ResetPassword() {
   const handleChange = (event: any) => {
     setFormData({
       name: event.target.name,
-      value: event.target.value,
+      value: event.target.value.trim(),
       touched: true,
       error: getError(event.target.name, event.target.value)
     });

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -134,7 +134,7 @@ export default function SignIn() {
   const handleChange = (event: any) => {
     setFormData({
       name: event.target.name,
-      value: event.target.value,
+      value: event.target.value.trim(),
       touched: true,
       error: getError(event.target.name, event.target.value)
     });

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -187,7 +187,7 @@ export default function SignUp() {
   const handleChange = (event: any) => {
     setFormData({
       name: event.target.name,
-      value: event.target.value,
+      value: event.target.value.trim(),
       touched: true,
       error: getError(event.target.name, event.target.value)
     });


### PR DESCRIPTION
## Description

Add trim to sign in sign up page to remove whitespace in form fields and add sort by time to Report page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ