### PR TITLE
fix: ME-615-responsive-not-auto-scroll-into-current-tab

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { Box } from "@mui/material";
 
@@ -136,6 +136,9 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
     }
   ];
 
+  useEffect(() => {
+    document.getElementById(`step-${currentStep}`)?.scrollIntoView(true);
+  }, [currentStep]);
   if (!tabsRenderConfig) return null;
 
   return (
@@ -144,6 +147,7 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
         {stepper.map((step, idx) => {
           return (
             <Step
+              id={`step-${idx}`}
               component={"span"}
               key={idx}
               active={+(currentStep === idx)}

--- a/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Box } from "@mui/material";
 import { useHistory, useParams } from "react-router";
 
@@ -111,6 +111,10 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
     }
   ];
 
+  useEffect(() => {
+    document.getElementById(`step-${currentStep}`)?.scrollIntoView();
+  }, [currentStep]);
+
   if (!renderTabsSPO) return null;
 
   return (
@@ -118,6 +122,7 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
       <Box display={"flex"} justifyContent={"space-between"}>
         {stepper.map((step, idx) => (
           <Step
+            id={`step-${idx}`}
             component={"span"}
             key={idx}
             active={+(currentStep === idx)}


### PR DESCRIPTION
## Description

Not auto scroll into current tab

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/9698ec3e-657e-4f1f-87b6-927e17662e09)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/83749c96-5f37-45aa-8c9f-94beae14ec1c)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/6f5ef60a-3ec9-4132-9159-8f1672ae66ae)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/135013231/f27dc26e-1456-4605-8143-349cc6fd9dbb)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ