### PR TITLE
Fix: MET-1251 Finding 1 handle Plural time end in epoch

### DIFF
--- a/src/components/DelegationPool/DelegationOverview/index.tsx
+++ b/src/components/DelegationPool/DelegationOverview/index.tsx
@@ -44,6 +44,9 @@ const OverViews: React.FC = () => {
     data?.countDownEndTime ? data.countDownEndTime + now.utcOffset() * 60 * 1000 : 0,
     "millisecond"
   );
+  const days = duration.days();
+  const hours = duration.hours();
+  const minutes = duration.minutes();
   return (
     <Card
       title="Delegation Pools Explorer"
@@ -65,7 +68,9 @@ const OverViews: React.FC = () => {
               <Box component="span" sx={{ color: (theme) => theme.palette.grey[400], textAlign: "left" }}>
                 End in:{" "}
                 <StyledCard.Comment>
-                  {duration.days()} day {duration.hours()} hours {duration.minutes()} minutes
+                  {`${days} day${days > 1 ? 's' : ''} `}
+                  {`${hours} hour${hours > 1 ? 's' : ''} `}
+                  {`${minutes} minute${minutes > 1 ? 's' : ''}`}
                 </StyledCard.Comment>
               </Box>
             </StyledCard.Content>


### PR DESCRIPTION
## Description

Handle Plural time end in epoch.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1251](https://cardanofoundation.atlassian.net/browse/MET-1251)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1251]: https://cardanofoundation.atlassian.net/browse/MET-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ