### PR TITLE
test: fix: MET-615 pool delegation detail epoch table loading position wrong

### DIFF
--- a/src/components/commons/Table/styles.ts
+++ b/src/components/commons/Table/styles.ts
@@ -140,7 +140,7 @@ export const WrappModalScrollBar = styled(Box)(
 export const Wrapper = styled(Box)<{ maxHeight?: number | string; height: number }>(
   ({ maxHeight, height, theme }) => `
   overflow-x: auto;
-  height: ${height || "800px"};
+  height: ${height || 800}px;
   background: ${theme.palette.common.white};
   padding: ${theme.spacing(1)};
   padding-top: 0;
@@ -173,17 +173,13 @@ export const Wrapper = styled(Box)<{ maxHeight?: number | string; height: number
 `
 );
 
-export const TableFullWidth = styled("table")(
-  ({ theme }) => `
+export const TableFullWidth = styled("table")`
   border-collapse: separate;
   border-spacing: 0;
   min-width: 100%;
   width: max-content;
-  ${theme.breakpoints.down("sm")} {
-    position: relative;
-  }
-`
-);
+  position: relative;
+`;
 
 export const InputNumber = styled("input")<{ length: number }>(({ theme, length }) => ({
   width: length + "ch !important",


### PR DESCRIPTION
## Description

Fix loading position of epoch table in pool delegation detail page.
Device: Ipad pro (Chrome, Safari)

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome (Ipad pro)

| Before (loading of epoch table outside table) | After (loading of epoch table inside table) |
|----------|--------|
|![unnamed](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/098fe3a8-579f-45ed-a680-3523c986b728)|![unnamed (2)](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/1018893e-1848-43c6-85ea-0ace3da98b6e)|
| |![unnamed (1)](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/7535fcf8-807c-4580-a626-3a4aca14be38)|


#### Safari
##### _Before_

Same Chrome

##### _After_

Same Chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ