### PR TITLE
Fix: MET-1256 Finding 1 Fix No Tooltip when hover browser or Resource on tab sidebar

### DIFF
--- a/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
+++ b/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
@@ -122,9 +122,9 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
                       ...itemStyle(theme, sidebar),
                       ...(`menu-${index}` === active
                         ? {
-                            backgroundColor: (theme) => `${theme.palette.success.light} !important`,
-                            color: (theme) => theme.palette.success.dark
-                          }
+                          backgroundColor: (theme) => `${theme.palette.success.light} !important`,
+                          color: (theme) => theme.palette.success.dark
+                        }
                         : { color: (theme) => theme.palette.grey[400] })
                     })}
                   >
@@ -188,9 +188,9 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
                             sx={(theme) => ({
                               ...itemStyle(theme, sidebar),
                               ...(pathname === href ||
-                              (pathname.split("/").length > 2 && href.includes(pathname.split("/")[1])) ||
-                              (href === "/timeline" &&
-                                (pathname.includes("delegator-lifecycle") || pathname.includes("spo-lifecycle")))
+                                (pathname.split("/").length > 2 && href.includes(pathname.split("/")[1])) ||
+                                (href === "/timeline" &&
+                                  (pathname.includes("delegator-lifecycle") || pathname.includes("spo-lifecycle")))
                                 ? { backgroundColor: (theme) => `${theme.palette.success.dark} !important` }
                                 : {}),
                               paddingLeft: "70px",
@@ -212,9 +212,9 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
                               open={sidebar ? 1 : 0}
                               active={
                                 pathname === href ||
-                                (pathname.split("/").length > 2 && href.includes(pathname.split("/")[1])) ||
-                                (href === "/timeline" &&
-                                  (pathname.includes("delegator-lifecycle") || pathname.includes("spo-lifecycle")))
+                                  (pathname.split("/").length > 2 && href.includes(pathname.split("/")[1])) ||
+                                  (href === "/timeline" &&
+                                    (pathname.includes("delegator-lifecycle") || pathname.includes("spo-lifecycle")))
                                   ? 1
                                   : 0
                               }
@@ -240,75 +240,78 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
           }}
         />
         {footerMenus.map((item, index) => {
-          const { href, title, children, icon } = item;
+          const { href, title, children, icon, tooltip } = item;
+          const tooltipTitle = `${!sidebar ? `${title}${title && tooltip ? `: ` : ``}` : ``}${tooltip || ``}`;
           return (
             <React.Fragment key={index}>
-              {href ? (
-                isExtenalLink(href) ? (
-                  <ListItem
-                    button
-                    onClick={() => window.open(href, "_blank")}
-                    sx={(theme) => itemStyle(theme, sidebar)}
-                  >
-                    {icon ? <MenuIcon src={icon} alt={title} iconOnly={!sidebar ? 1 : 0} /> : null}
-                    <MenuText primary={title} open={sidebar ? 1 : 0} />
-                  </ListItem>
+              <CustomTooltip key={index} title={tooltipTitle} placement="right">
+                {href ? (
+                  isExtenalLink(href) ? (
+                    <ListItem
+                      button
+                      onClick={() => window.open(href, "_blank")}
+                      sx={(theme) => itemStyle(theme, sidebar)}
+                    >
+                      {icon ? <MenuIcon src={icon} alt={title} iconOnly={!sidebar ? 1 : 0} /> : null}
+                      <MenuText primary={title} open={sidebar ? 1 : 0} />
+                    </ListItem>
+                  ) : (
+                    <ListItem
+                      button
+                      component={Link}
+                      to={href}
+                      selected={pathname === href}
+                      sx={(theme) => ({
+                        ...itemStyle(theme, sidebar),
+                        ...(pathname === href
+                          ? { backgroundColor: (theme) => `${theme.palette.success.dark} !important` }
+                          : {})
+                      })}
+                    >
+                      {icon ? (
+                        <MenuIcon src={icon} alt={title} iconOnly={!sidebar ? 1 : 0} active={pathname === href ? 1 : 0} />
+                      ) : null}
+                      <MenuText primary={title} open={sidebar ? 1 : 0} active={pathname === href ? 1 : 0} />
+                    </ListItem>
+                  )
                 ) : (
                   <ListItem
                     button
-                    component={Link}
-                    to={href}
-                    selected={pathname === href}
+                    onClick={() => handleOpen(`footer-${index}`)}
                     sx={(theme) => ({
                       ...itemStyle(theme, sidebar),
-                      ...(pathname === href
-                        ? { backgroundColor: (theme) => `${theme.palette.success.dark} !important` }
-                        : {})
-                    })}
-                  >
-                    {icon ? (
-                      <MenuIcon src={icon} alt={title} iconOnly={!sidebar ? 1 : 0} active={pathname === href ? 1 : 0} />
-                    ) : null}
-                    <MenuText primary={title} open={sidebar ? 1 : 0} active={pathname === href ? 1 : 0} />
-                  </ListItem>
-                )
-              ) : (
-                <ListItem
-                  button
-                  onClick={() => handleOpen(`footer-${index}`)}
-                  sx={(theme) => ({
-                    ...itemStyle(theme, sidebar),
-                    ...(`footer-${index}` === active
-                      ? {
+                      ...(`footer-${index}` === active
+                        ? {
                           backgroundColor: `${theme.palette.success.light} !important`,
                           color: theme.palette.success.dark
                         }
-                      : { color: theme.palette.grey[400] })
-                  })}
-                >
-                  {icon ? (
-                    <MenuIcon
-                      src={icon}
-                      alt={title}
-                      iconOnly={!sidebar ? 1 : 0}
-                      text={children?.length ? 1 : 0}
+                        : { color: theme.palette.grey[400] })
+                    })}
+                  >
+                    {icon ? (
+                      <MenuIcon
+                        src={icon}
+                        alt={title}
+                        iconOnly={!sidebar ? 1 : 0}
+                        text={children?.length ? 1 : 0}
+                        active={`footer-${index}` === active ? 1 : 0}
+                      />
+                    ) : null}
+                    <MenuText
+                      primary={title}
+                      open={sidebar ? 1 : 0}
                       active={`footer-${index}` === active ? 1 : 0}
+                      text={1}
                     />
-                  ) : null}
-                  <MenuText
-                    primary={title}
-                    open={sidebar ? 1 : 0}
-                    active={`footer-${index}` === active ? 1 : 0}
-                    text={1}
-                  />
-                  {sidebar &&
-                    (children?.length ? (
-                      <IconMenu component={"span"}>
-                        {`footer-${index}` === active ? <BiChevronUp size={18} /> : <BiChevronDown size={18} />}
-                      </IconMenu>
-                    ) : null)}
-                </ListItem>
-              )}
+                    {sidebar &&
+                      (children?.length ? (
+                        <IconMenu component={"span"}>
+                          {`footer-${index}` === active ? <BiChevronUp size={18} /> : <BiChevronDown size={18} />}
+                        </IconMenu>
+                      ) : null)}
+                  </ListItem>
+                )}
+              </CustomTooltip>
               {children?.length ? (
                 <Collapse in={`footer-${index}` === active} timeout="auto" unmountOnExit>
                   <SubMenu disablePadding>


### PR DESCRIPTION
## Description

Fix No Tooltip when hover browser or Resource and on tab sidebar.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1256](https://cardanofoundation.atlassian.net/browse/MET-1256)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/63a3890a-77b7-4bcc-9a2c-4b5bbda75d6d)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/c61917fd-0977-4e9c-bd42-b4e93caff3f0)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/96c3e543-a192-4b96-9263-80d1ddd72b23)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1256]: https://cardanofoundation.atlassian.net/browse/MET-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ