### PR TITLE
Fix: MET-1258 Finding 1 display start time and end time for epoch

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -8,7 +8,7 @@ import { AdaPriceIcon, CurentEpochIcon, LiveStakeIcon, MarketCapIcon } from "src
 import { details } from "src/commons/routers";
 import { API } from "src/commons/utils/api";
 import { MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
-import { formatADA, formatADAFull, numberWithCommas } from "src/commons/utils/helper";
+import { formatADA, formatADAFull, formatDateTimeLocal, numberWithCommas } from "src/commons/utils/helper";
 import { RootState } from "src/stores/types";
 import CustomTooltip from "src/components/commons/CustomTooltip";
 import RateWithIcon from "src/components/commons/RateWithIcon";
@@ -142,6 +142,22 @@ const HomeStatistic = () => {
                 {isMobile ? <br /> : null}
                 <XValue>
                   <b>{numberWithCommas(currentEpoch?.account)}</b>
+                </XValue>
+                <br />
+                <XSmall>Start time: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue>
+                  <b style={{
+                    whiteSpace: isGalaxyFoldSmall ? "normal" : "nowrap",
+                  }}>{formatDateTimeLocal(currentEpoch?.startTime)}</b>
+                </XValue>
+                <br />
+                <XSmall>End time: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue>
+                  <b style={{
+                    whiteSpace: isGalaxyFoldSmall ? "normal" : "nowrap",
+                  }}>{formatDateTimeLocal(currentEpoch?.endTime)}</b>
                 </XValue>
               </Content>
             </Link>

--- a/src/components/SystemLoader/index.tsx
+++ b/src/components/SystemLoader/index.tsx
@@ -35,12 +35,12 @@ export const SystemLoader = () => {
   useEffect(() => {
     if (currentEpoch) {
       startTime.current = Date.now();
-      const { no, slot, totalSlot, account } = currentEpoch;
+      const { no, slot, totalSlot, account, startTime: startTimeEpoch, endTime: endTimeEpoch } = currentEpoch;
       const interval = setInterval(() => {
         const newSlot = slot + Math.floor((Date.now() - startTime.current) / 1000);
         const isCrawlerStop = newSlot - MAX_SLOT_EPOCH > REFRESH_TIMES.CURRENT_EPOCH;
         const newNo = newSlot >= MAX_SLOT_EPOCH && !isCrawlerStop ? no + 1 : no;
-        setCurrentEpoch({ slot: newSlot % MAX_SLOT_EPOCH, no: newNo, totalSlot, account });
+        setCurrentEpoch({ slot: newSlot % MAX_SLOT_EPOCH, no: newNo, totalSlot, account, startTime: startTimeEpoch, endTime: endTimeEpoch });
       }, 1000);
       return () => clearInterval(interval);
     }

--- a/src/types/epoch.d.ts
+++ b/src/types/epoch.d.ts
@@ -34,4 +34,6 @@ interface EpochCurrentType {
   slot: number;
   totalSlot: number;
   account: number;
+  endTime: string;
+  startTime: string;
 }


### PR DESCRIPTION
## Description

Display start time and end time for epoch

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1258](https://cardanofoundation.atlassian.net/browse/MET-1258)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/1f392356-8e13-4ce0-9a16-040a5f2606f6)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/51647dfc-9ca8-4809-b83e-8edae86e37c2)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1258]: https://cardanofoundation.atlassian.net/browse/MET-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ