### PR TITLE
fix: MET-1104 update tab button

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/Tabular/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/Tabular/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Box } from "@mui/material";
 import { useHistory, useParams } from "react-router";
 
@@ -71,15 +70,7 @@ interface ITabularProps {
 
 const Tabular = ({ tabsRenderConfig }: ITabularProps) => {
   const { stakeId = "", tab = "registration" } = useParams<{ stakeId: string; tab: DelegationStep }>();
-  const [listTabs, setListTabs] = useState<ITabularTab[]>(tabs);
   const history = useHistory();
-
-  useEffect(() => {
-    if (tabsRenderConfig) {
-      const filteredTabs = tabs.filter((tab: ITabularTab) => tabsRenderConfig[tab.keyCheckShow]);
-      setListTabs(filteredTabs);
-    }
-  }, [tabsRenderConfig]);
 
   if (!tabsRenderConfig) return null;
 
@@ -90,7 +81,7 @@ const Tabular = ({ tabsRenderConfig }: ITabularProps) => {
   return (
     <Box mt={5}>
       <TabularOverview />
-      <StakeTab tabs={listTabs} initTab={tab} onChangeTab={onChangeTab} />
+      <StakeTab tabsRenderConfig={tabsRenderConfig} tabs={tabs} initTab={tab} onChangeTab={onChangeTab} />
     </Box>
   );
 };

--- a/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
-import { Box } from "@mui/material";
+import { Box, IconButton, useTheme } from "@mui/material";
 
 import {
   DelegationIcon,
@@ -16,6 +16,7 @@ import {
 import { ListStakeKeyResponse } from "src/pages/DelegatorLifecycle";
 import { details } from "src/commons/routers";
 import { useScreen } from "src/commons/hooks/useScreen";
+import CustomTooltip from "src/components/commons/CustomTooltip";
 
 import {
   ADATransfersButton,
@@ -56,21 +57,29 @@ interface StepperProps {
 interface Props {
   currentStep: number;
   setCurrentStep: (step: number) => void;
-  tabsRenderConfig?: ListStakeKeyResponse;
+  tabsRenderConfig: ListStakeKeyResponse | null;
 }
 
 const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: Props) => {
   const history = useHistory();
   const { isMobile } = useScreen();
+  const { palette } = useTheme();
   const { stakeId = "" } = useParams<{
     stakeId: string;
   }>();
   const [open, setOpen] = useState(false);
   const [openDescriptionModal, setOpenDescriptionModal] = useState(false);
+  if (!tabsRenderConfig) return null;
 
   const stepper: StepperProps[] = [
     {
-      icon: <RegistrationIcon width={"25px"} height={"25px"} fill={currentStep >= 0 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <RegistrationIcon
+          width={"25px"}
+          height={"25px"}
+          fill={tabsRenderConfig["hasRegistration"] ? "#fff" : "#98A2B3"}
+        />
+      ),
       title: "Registration",
       component: <Registration />,
       description: (
@@ -83,7 +92,9 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
       keyCheckShow: "hasRegistration"
     },
     {
-      icon: <DelegationIcon width={"25px"} height={"25px"} fill={currentStep >= 1 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <DelegationIcon width={"25px"} height={"25px"} fill={tabsRenderConfig["hasDelegation"] ? "#fff" : "#98A2B3"} />
+      ),
       title: "Delegation",
       component: <Delegation />,
       description: (
@@ -96,7 +107,13 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
       keyCheckShow: "hasDelegation"
     },
     {
-      icon: <RewardsDistributionIcon width={"25px"} height={"25px"} fill={currentStep >= 2 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <RewardsDistributionIcon
+          width={"25px"}
+          height={"25px"}
+          fill={tabsRenderConfig["hashRewards"] ? "#fff" : "#98A2B3"}
+        />
+      ),
       title: "Rewards Distribution",
       component: <RewardsDistribution />,
       description: (
@@ -109,7 +126,13 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
       keyCheckShow: "hashRewards"
     },
     {
-      icon: <RewardsWithdrawalIcon width={"25px"} height={"25px"} fill={currentStep >= 3 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <RewardsWithdrawalIcon
+          width={"25px"}
+          height={"25px"}
+          fill={tabsRenderConfig["hasWithdrawal"] ? "#fff" : "#98A2B3"}
+        />
+      ),
       title: "Rewards Withdrawal",
       component: <RewardsWithdrawal />,
       description: (
@@ -122,7 +145,13 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
       keyCheckShow: "hasWithdrawal"
     },
     {
-      icon: <DeredistrationIcon width={"25px"} height={"25px"} fill={currentStep >= 4 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <DeredistrationIcon
+          width={"25px"}
+          height={"25px"}
+          fill={tabsRenderConfig["hasDeRegistration"] ? "#fff" : "#98A2B3"}
+        />
+      ),
       title: "Deregistration",
       component: <Deregistration />,
       description: (
@@ -136,7 +165,15 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
     }
   ];
 
-  if (!tabsRenderConfig) return null;
+  const renderBackground = (isActive: boolean, hasData: boolean) => {
+    if (isActive) {
+      return `${palette.green[600]} !important`;
+    }
+    if (hasData) {
+      return `${palette.grey[700]} !important`;
+    }
+    return `${palette.grey[200]} !important`;
+  };
 
   return (
     <Box>
@@ -144,23 +181,32 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
         {stepper.map((step, idx) => {
           return (
             <Step
-              component={"span"}
               key={idx}
+              component={tabsRenderConfig[step.keyCheckShow] ? "span" : CustomTooltip}
               active={+(currentStep === idx)}
-              display={tabsRenderConfig[step.keyCheckShow] ? "block" : "none"}
+              title={tabsRenderConfig[step.keyCheckShow] ? undefined : "There is no record at this time"}
             >
-              <StepButton
-                active={+(currentStep === idx)}
-                onClick={() => {
-                  setCurrentStep(idx);
-                  history.replace(details.staking(stakeId, "timeline", step.key));
-                }}
-              >
-                {step.icon}
-              </StepButton>
-              <TitleStep currentstep={currentStep} index={idx} px={2}>
-                {step.title}
-              </TitleStep>
+              <Box>
+                <StepButton
+                  component={IconButton}
+                  active={+(currentStep === idx)}
+                  onClick={() => {
+                    if (tabsRenderConfig[step.keyCheckShow]) {
+                      setCurrentStep(idx);
+                      history.replace(details.staking(stakeId, "timeline", step.key));
+                    }
+                  }}
+                  bgcolor={renderBackground(currentStep === idx, tabsRenderConfig[step.keyCheckShow])}
+                  color={({ palette }) =>
+                    tabsRenderConfig[step.keyCheckShow] ? palette.common.white : palette.grey[300]
+                  }
+                >
+                  {step.icon}
+                </StepButton>
+                <TitleStep active={+tabsRenderConfig[step.keyCheckShow]} px={2}>
+                  {step.title}
+                </TitleStep>
+              </Box>
             </Step>
           );
         })}

--- a/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
@@ -1,4 +1,4 @@
-import { Box, Button, IconButton, Typography, alpha, styled } from "@mui/material";
+import { Box, Button, Typography, alpha, styled } from "@mui/material";
 
 export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
   width: "100%",
@@ -12,19 +12,14 @@ export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
   }
 }));
 
-export const StepButton = styled(IconButton)<{ active: number }>(({ theme, active }) => ({
+export const StepButton = styled(Box)<{ active: number }>(({ theme, active }) => ({
   background: active ? theme.palette.green[600] : theme.palette.grey[200],
   ":hover": {
     background: active ? theme.palette.green[600] : theme.palette.grey[200]
   }
 }));
-export const TitleStep = styled(Box)<{ currentstep: number; index: number }>(({ theme, currentstep, index }) => ({
-  color:
-    currentstep === index
-      ? theme.palette.grey[700]
-      : currentstep > index
-      ? theme.palette.grey[400]
-      : theme.palette.grey[300],
+export const TitleStep = styled(Box)<{ active: number }>(({ theme, active }) => ({
+  color: active ? theme.palette.grey[700] : theme.palette.grey[300],
   fontWeight: "bold",
   fontSize: "0.875rem",
   marginTop: theme.spacing(1),

--- a/src/components/StakingLifeCycle/SPOLifecycle/Tablular/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/Tablular/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Box } from "@mui/material";
 import { useHistory, useParams } from "react-router";
 
@@ -56,23 +55,14 @@ const Tabular = ({ renderTabsSPO }: ITabular) => {
   const { poolId = "", tab = "registration" } = useParams<{ poolId: string; tab: SPOStep }>();
   const history = useHistory();
 
-  const [listTabs, setListTabs] = useState<SPOTabItem[]>(tabs);
-
   const onChangeTab = (tab: any) => {
     history.replace(details.spo(poolId, "tabular", tab));
   };
 
-  useEffect(() => {
-    if (renderTabsSPO) {
-      const filteredList = tabs.filter((tab: SPOTabItem) => renderTabsSPO[tab.keyCheckShow]);
-      setListTabs(filteredList);
-    }
-  }, [renderTabsSPO]);
-
   return (
     <Box mt={5}>
       <TabularOverview />
-      <StakeTab tabs={listTabs} initTab={tab} onChangeTab={onChangeTab} />
+      <StakeTab tabsRenderConfig={renderTabsSPO} tabs={tabs} initTab={tab} onChangeTab={onChangeTab} />
     </Box>
   );
 };

--- a/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box } from "@mui/material";
+import { Box, IconButton, useTheme } from "@mui/material";
 import { useHistory, useParams } from "react-router";
 
 import { useScreen } from "src/commons/hooks/useScreen";
@@ -14,6 +14,7 @@ import {
   RegistrationIcon
 } from "src/commons/resources";
 import { details } from "src/commons/routers";
+import CustomTooltip from "src/components/commons/CustomTooltip";
 
 import {
   DeregistrationSPOProcessDescription,
@@ -58,10 +59,15 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
   const [openDescriptionModal, setOpenDescriptionModal] = useState(false);
   const history = useHistory();
   const { isMobile } = useScreen();
+  const { palette } = useTheme();
+
+  if (!renderTabsSPO) return null;
 
   const stepper: StepperProps[] = [
     {
-      icon: <RegistrationIcon width={"25px"} height={"25px"} fill={currentStep >= 0 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <RegistrationIcon width={"25px"} height={"25px"} fill={renderTabsSPO["isRegistration"] ? "#fff" : "#98A2B3"} />
+      ),
       title: "Registration",
       component: <Registration />,
       description: (
@@ -74,7 +80,7 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
       keyCheckShow: "isRegistration"
     },
     {
-      icon: <PoolUpdateIcon width={"25px"} height={"25px"} fill={currentStep >= 1 ? "#fff" : "#98A2B3"} />,
+      icon: <PoolUpdateIcon width={"25px"} height={"25px"} fill={renderTabsSPO["isUpdate"] ? "#fff" : "#98A2B3"} />,
       title: "Pool Updates",
       component: <PoollUpdates />,
       description: (
@@ -87,7 +93,7 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
       keyCheckShow: "isUpdate"
     },
     {
-      icon: <OperatorRewardIcon width={"25px"} height={"25px"} fill={currentStep >= 2 ? "#fff" : "#98A2B3"} />,
+      icon: <OperatorRewardIcon width={"25px"} height={"25px"} fill={renderTabsSPO["isReward"] ? "#fff" : "#98A2B3"} />,
       title: "Operator Rewards",
       component: <OperatorReward />,
       description: (
@@ -97,7 +103,13 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
       keyCheckShow: "isReward"
     },
     {
-      icon: <DeredistrationIcon width={"25px"} height={"25px"} fill={currentStep >= 3 ? "#fff" : "#98A2B3"} />,
+      icon: (
+        <DeredistrationIcon
+          width={"25px"}
+          height={"25px"}
+          fill={renderTabsSPO["isDeRegistration"] ? "#fff" : "#98A2B3"}
+        />
+      ),
       title: "Deregistration",
       component: <Deregistration />,
       description: (
@@ -111,30 +123,43 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
     }
   ];
 
-  if (!renderTabsSPO) return null;
+  const renderBackground = (isActive: boolean, hasData: boolean) => {
+    if (isActive) {
+      return `${palette.green[600]} !important`;
+    }
+    if (hasData) {
+      return `${palette.grey[700]} !important`;
+    }
+    return `${palette.grey[200]} !important`;
+  };
 
   return (
     <StyledComponent>
       <Box display={"flex"} justifyContent={"space-between"}>
         {stepper.map((step, idx) => (
           <Step
-            component={"span"}
             key={idx}
             active={+(currentStep === idx)}
-            display={renderTabsSPO[step.keyCheckShow] ? "block" : "none"}
+            component={renderTabsSPO[step.keyCheckShow] ? "span" : CustomTooltip}
+            title={renderTabsSPO[step.keyCheckShow] ? undefined : "There is no record at this time"}
           >
-            <StepButton
-              active={+(currentStep === idx)}
-              onClick={() => {
-                history.replace(details.spo(poolId, "timeline", step.key));
-                setCurrentStep(idx);
-              }}
-            >
-              {step.icon}
-            </StepButton>
-            <TitleStep currentStep={currentStep} index={idx}>
-              {step.title}
-            </TitleStep>
+            <Box>
+              <StepButton
+                component={IconButton}
+                active={+(currentStep === idx)}
+                onClick={() => {
+                  if (renderTabsSPO[step.keyCheckShow]) {
+                    history.replace(details.spo(poolId, "timeline", step.key));
+                    setCurrentStep(idx);
+                  }
+                }}
+                bgcolor={renderBackground(currentStep === idx, renderTabsSPO[step.keyCheckShow])}
+                color={({ palette }) => (renderTabsSPO[step.keyCheckShow] ? palette.common.white : palette.grey[300])}
+              >
+                {step.icon}
+              </StepButton>
+              <TitleStep active={+renderTabsSPO[step.keyCheckShow]}>{step.title}</TitleStep>
+            </Box>
           </Step>
         ))}
       </Box>

--- a/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
@@ -1,4 +1,4 @@
-import { Box, Button, IconButton, Typography, alpha, styled } from "@mui/material";
+import { Box, Button, Typography, alpha, styled } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
@@ -10,23 +10,18 @@ export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
   }
 }));
 
-export const StepButton = styled(IconButton)<{ active: number }>(({ theme, active }) => ({
+export const StepButton = styled(Box)<{ active: number }>(({ theme, active }) => ({
   background: active ? theme.palette.green[600] : theme.palette.grey[200],
   ":hover": {
     background: active ? theme.palette.green[600] : theme.palette.grey[200]
   }
 }));
-export const TitleStep = styled(Box)<{ currentStep: number; index: number }>(({ theme, currentStep, index }) => ({
-  color:
-    currentStep === index
-      ? theme.palette.grey[700]
-      : currentStep > index
-      ? theme.palette.grey[400]
-      : theme.palette.grey[300],
+export const TitleStep = styled(Box)<{ active: number }>(({ theme, active }) => ({
+  color: active ? theme.palette.grey[700] : theme.palette.grey[300],
   fontWeight: "bold",
   fontSize: "0.875rem",
   marginTop: theme.spacing(1),
-  [theme.breakpoints.down("sm")]: {
+  [theme.breakpoints.down("md")]: {
     whiteSpace: "nowrap"
   }
 }));

--- a/src/components/TabularView/StakeTab/index.tsx
+++ b/src/components/TabularView/StakeTab/index.tsx
@@ -2,6 +2,10 @@ import React, { useState } from "react";
 import { Tab, Box, useTheme } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
 
+import { ListStakeKeyResponse } from "src/pages/DelegatorLifecycle";
+import CustomTooltip from "src/components/commons/CustomTooltip";
+import { ListTabResponseSPO } from "src/pages/SPOLifecycle";
+
 import { StyledTabList, TabHead, TitleTab } from "./styles";
 import CustomIcon from "../../commons/CustomIcon";
 
@@ -10,20 +14,24 @@ export interface StakeTabItem {
   label: React.ReactNode;
   key: string;
   component: React.ReactNode;
+  keyCheckShow?: string;
 }
 export interface StackTabProps {
   tabs: StakeTabItem[];
   initTab?: string;
   onChangeTab?: (tab: TabStakeDetail) => void;
+  tabsRenderConfig?: ListStakeKeyResponse | ListTabResponseSPO;
 }
 
-const StakeTab: React.FC<StackTabProps> = ({ tabs, initTab = "registration", onChangeTab }) => {
+const StakeTab: React.FC<StackTabProps> = ({ tabs, initTab = "registration", onChangeTab, tabsRenderConfig }) => {
   const [tabActive, setTabActive] = useState<string>(initTab);
   const theme = useTheme();
 
   const handleChange = (event: React.SyntheticEvent, tab: TabStakeDetail) => {
-    setTabActive(tab);
-    onChangeTab?.(tab);
+    if (tabsRenderConfig && tabsRenderConfig[tabs.find((t) => t.key === tab)?.keyCheckShow || ""]) {
+      setTabActive(tab);
+      onChangeTab?.(tab);
+    }
   };
 
   return (
@@ -37,23 +45,31 @@ const StakeTab: React.FC<StackTabProps> = ({ tabs, initTab = "registration", onC
             variant="scrollable"
             visibleScrollbar={true}
           >
-            {tabs.map(({ icon: Icon, key, label }) => (
+            {tabs.map(({ icon: Icon, key, label, keyCheckShow }) => (
               <Tab
                 key={key}
                 value={key}
                 style={{ padding: "12px 0px", marginRight: 40 }}
                 label={
-                  <TabHead active={+(key === tabActive)} display={"flex"} alignItems="center">
-                    <CustomIcon
-                      icon={Icon}
-                      fill={key === "poolSize" ? "none" : "currentColor"}
-                      stroke={key === "poolSize" ? "currentColor" : "none"}
-                      width={25}
-                    />
-                    <TitleTab pl={1} active={+(key === tabActive)}>
-                      {label}
-                    </TitleTab>
-                  </TabHead>
+                  <CustomTooltip
+                    title={
+                      tabsRenderConfig && tabsRenderConfig[keyCheckShow || ""]
+                        ? undefined
+                        : "There is no record at this time"
+                    }
+                  >
+                    <TabHead active={+(key === tabActive)} display={"flex"} alignItems="center">
+                      <CustomIcon
+                        icon={Icon}
+                        fill={key === "poolSize" ? "none" : "currentColor"}
+                        stroke={key === "poolSize" ? "currentColor" : "none"}
+                        width={25}
+                      />
+                      <TitleTab pl={1} active={+(key === tabActive)}>
+                        {label}
+                      </TitleTab>
+                    </TabHead>
+                  </CustomTooltip>
                 }
               />
             ))}

--- a/src/pages/DelegatorLifecycle/index.tsx
+++ b/src/pages/DelegatorLifecycle/index.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "@mui/material";
+import { CircularProgress, useTheme } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router";
 import { useSelector } from "react-redux";
@@ -50,16 +50,9 @@ export interface ListStakeKeyResponse {
 
 const MODES: ViewMode[] = ["timeline", "tabular"];
 
-const dataTabsConfig = {
-  hasDeRegistration: true,
-  hasDelegation: true,
-  hasRegistration: true,
-  hasWithdrawal: true,
-  hashRewards: true
-};
-
 const DelegatorLifecycle = () => {
   const { stakeId = "", mode = "timeline", tab = "registration" } = useParams<Params>();
+
   const tabList: { [key in DelegationStep]: number } & { tablular: null } = {
     registration: 0,
     delegation: 1,
@@ -80,6 +73,9 @@ const DelegatorLifecycle = () => {
   const { sidebar } = useSelector(({ user }: RootState) => user);
   const { isLoggedIn } = useAuth();
   const { data, error, initialized } = useFetch<IStakeKeyDetail>(`${API.STAKE.DETAIL}/${stakeId}`, undefined, false);
+  const { data: listTabs, loading: loadingListTabs } = useFetch<ListStakeKeyResponse>(
+    API.STAKE_LIFECYCLE.TABS(stakeId)
+  );
 
   useEffect(() => {
     setCurrentStep(tabList[validTab]);
@@ -129,16 +125,18 @@ const DelegatorLifecycle = () => {
             )}
           </BoxItemStyled>
         </BoxContainerStyled>
-        {dataTabsConfig && (
+        {loadingListTabs && <CircularProgress color="success" />}
+
+        {!loadingListTabs && listTabs && (
           <>
             {validMode === "timeline" ? (
               <DelegatorLifecycleComponent
                 currentStep={currentStep}
                 setCurrentStep={setCurrentStep}
-                tabsRenderConfig={dataTabsConfig}
+                tabsRenderConfig={listTabs}
               />
             ) : (
-              <Tabular tabsRenderConfig={dataTabsConfig} />
+              <Tabular tabsRenderConfig={listTabs} />
             )}
           </>
         )}

--- a/src/pages/SPOLifecycle/index.tsx
+++ b/src/pages/SPOLifecycle/index.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable no-debugger */
 import { useHistory, useParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
+import { CircularProgress } from "@mui/material";
 
 import { getShortWallet } from "src/commons/utils/helper";
 import CopyButton from "src/components/commons/CopyButton";
@@ -47,13 +49,6 @@ export interface ListTabResponseSPO {
   isDeRegistration: boolean;
 }
 
-const renderTabsSPO: ListTabResponseSPO = {
-  isRegistration: true,
-  isUpdate: true,
-  isReward: true,
-  isDeRegistration: true
-};
-
 const MODES: ViewMode[] = ["timeline", "tabular"];
 
 const SPOLifecycle = () => {
@@ -72,7 +67,9 @@ const SPOLifecycle = () => {
   };
 
   const { data, error, initialized } = useFetch<PoolInfo>(poolId ? API.SPO_LIFECYCLE.POOL_INFO(poolId) : "");
-
+  const { data: renderTabsSPO, loading: loadingListTabs } = useFetch<ListTabResponseSPO>(
+    API.SPO_LIFECYCLE.TABS(poolId)
+  );
   const validTab: SPOStep = tabList[tab] >= 0 ? tab : "registration";
   const validMode: ViewMode = MODES.find((item) => item === mode) || "timeline";
 
@@ -130,7 +127,8 @@ const SPOLifecycle = () => {
             )}
           </BoxItemStyled>
         </BoxContainerStyled>
-        {renderTabsSPO && (
+        {loadingListTabs && <CircularProgress color="success" />}
+        {renderTabsSPO && !loadingListTabs && (
           <>
             {validMode === "timeline" ? (
               <SPOLifecycleComponent


### PR DESCRIPTION
## Description

Update tab in staking  
- green is active
- black is has action
- grey is not has action and show tooltip

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-1104)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

**SPO  timeline**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/98dd843b-4855-42be-b446-7db9c89b8794)

**SPO tabular**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/5ae25f1d-3675-427d-a226-db9ada573fc7)

**Delegator timeline**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/fd162107-05d4-4ffb-a280-da83a1127920)

**Delegator tabular**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/9cc2055b-919c-4f19-8fb2-32e794a0b5ac)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)