### PR TITLE
fix: not destroy modal when close

### DIFF
--- a/src/components/TokenAutocomplete/index.tsx
+++ b/src/components/TokenAutocomplete/index.tsx
@@ -192,9 +192,22 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
     }
   ];
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal
+      open={open}
+      onClose={() => {
+        onClose();
+        setValue("");
+        setSearch("");
+      }}
+    >
       <ModalContainer>
-        <ButtonClose onClick={onClose}>
+        <ButtonClose
+          onClick={() => {
+            onClose();
+            setValue("");
+            setSearch("");
+          }}
+        >
           <img src={CloseIcon} alt="icon close" />
         </ButtonClose>
         <Box textAlign={"left"} fontSize="1.5rem" fontWeight="bold" fontFamily={'"Roboto", sans-serif '}>


### PR DESCRIPTION
## Description

Clear text search token when modal close

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
**After search token and reopen modal**

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/d88507fc-d134-4bc4-9d92-a80cd464212d)


##### _After_
**After search token and reopen modal**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/7ac2c0f7-9053-4b8c-af7b-53570b9d133d)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)