### PR TITLE
fix: MET-1272 padding UTXOs

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/UTXOs/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/UTXOs/index.tsx
@@ -85,6 +85,7 @@ const Card = ({
                               </Box>
                             </CustomTooltip>
                           </Link>
+                          <Box fontWeight={"bold"}>#{item?.index}</Box>
                           <CopyButton text={item.txHash} />
                         </Box>
                       </Box>
@@ -93,7 +94,13 @@ const Card = ({
                     <Box />
                   )}
                   <Box display={"flex"} justifyContent="space-between" alignItems={"center"}>
-                    <Box display={"flex"} alignItems="center" justifyContent={"flex-start"} pr={1}>
+                    <Box
+                      display={"flex"}
+                      alignItems="center"
+                      justifyContent={"flex-start"}
+                      pr={1}
+                      pl={type === "down" ? 2 : 0}
+                    >
                       {type === "down" ? "From" : "To"}:
                     </Box>
                     <Box display={"flex"} justifyContent="space-between" flex={"1"} alignItems={"center"}>
@@ -128,7 +135,7 @@ const Card = ({
                       flexDirection={isMobile ? "column" : "row"}
                       paddingTop="5px"
                     >
-                      <Box mr={3} minWidth={180}>
+                      <Box mr={3} minWidth={180} pl={type === "down" ? 2 : 0}>
                         <Box
                           display={"flex"}
                           flexDirection={isMobile ? "column" : "row"}

--- a/src/types/transactions.d.ts
+++ b/src/types/transactions.d.ts
@@ -148,6 +148,7 @@ interface Transaction {
       address: string;
       value: number;
       txHash: string;
+      index: string;
       tokens: Token[];
       stakeAddress?: string;
     }[];
@@ -156,6 +157,7 @@ interface Transaction {
       value: number;
       txHash: string;
       tokens: Token[];
+      index: string;
       stakeAddress?: string;
     }[];
   };


### PR DESCRIPTION
## Description

add index in UTXOs and padding address and stake address

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-1272)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/482376fc-28eb-4c22-bc72-5599f4bc98ff)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/747b5968-d6c5-4730-8b19-fea19bafe49f)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)