### PR TITLE
Fix: MET-1271 Finding 4 Add missing column of block table in Epock De…

### DIFF
--- a/src/components/EpochDetail/EpochBlockList/index.tsx
+++ b/src/components/EpochDetail/EpochBlockList/index.tsx
@@ -4,14 +4,15 @@ import { stringify } from "qs";
 
 import Card from "src/components/commons/Card";
 import Table, { Column } from "src/components/commons/Table";
-import { formatADAFull, getPageInfo, getShortHash, numberWithCommas } from "src/commons/utils/helper";
+import { formatADAFull, formatDateTimeLocal, getPageInfo, getShortHash, numberWithCommas } from "src/commons/utils/helper";
 import { details } from "src/commons/routers";
 import useFetchList from "src/commons/hooks/useFetchList";
 import { API } from "src/commons/utils/api";
 import ADAicon from "src/components/commons/ADAIcon";
 import { REFRESH_TIMES } from "src/commons/utils/constants";
+import CustomTooltip from "src/components/commons/CustomTooltip";
 
-import { EpochNo, StyledOutput, StyledColorBlueDard, StyledContainer, StyledLink } from "./styles";
+import { EpochNo, StyledOutput, StyledColorBlueDard, StyledContainer, StyledLink, PriceWrapper } from "./styles";
 
 interface IEpochBlockList {
   epochId: string;
@@ -41,11 +42,21 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
       }
     },
     {
-      title: "Block",
+      title: "Block No",
       key: "block",
       minWidth: "100px",
       render: (r) => (
         <StyledLink to={details.block(r.blockNo || r.hash)}>{r.blockNo || getShortHash(r.hash || "")}</StyledLink>
+      )
+    },
+    {
+      title: "Block ID",
+      key: "blockId",
+      minWidth: "150px",
+      render: (r) => (
+        <CustomTooltip title={r.hash}>
+          <StyledLink to={details.block(r.blockNo || r.hash)}>{getShortHash(`${r.hash}`)}</StyledLink>
+        </CustomTooltip>
       )
     },
     {
@@ -68,6 +79,16 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
       render: (r) => <StyledColorBlueDard>{r.txCount || 0}</StyledColorBlueDard>
     },
     {
+      title: "Fees",
+      key: "fees",
+      render: (r) => (
+        <PriceWrapper>
+          {formatADAFull(r.totalFees)}
+          <ADAicon />
+        </PriceWrapper>
+      )
+    },
+    {
       title: "Output",
       key: "outSum",
       minWidth: "100px",
@@ -77,6 +98,12 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
           <ADAicon />
         </StyledOutput>
       )
+    },
+    {
+      title: "Created At",
+      key: "time",
+      minWidth: "100px",
+      render: (r) => <PriceWrapper>{formatDateTimeLocal(r.time)}</PriceWrapper>,
     }
   ];
 

--- a/src/components/EpochDetail/EpochBlockList/styles.ts
+++ b/src/components/EpochDetail/EpochBlockList/styles.ts
@@ -32,3 +32,9 @@ export const StyledOutput = styled("div")`
   align-items: center;
   gap: 10px;
 `;
+
+export const PriceWrapper = styled(StyledColorBlueDard)`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+`;


### PR DESCRIPTION
## Description

Finding4: Add Missing Column of Block table in Epoch Details screen

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1271](https://cardanofoundation.atlassian.net/browse/MET-1271)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/1323dcf0-2b8c-469f-bfb5-65253e9374dc)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/7859ad95-b9e8-48c9-9c35-0a423423225b)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1271]: https://cardanofoundation.atlassian.net/browse/MET-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ