### PR TITLE
fix: add default sort in operator reward

### DIFF
--- a/src/components/StakingLifeCycle/SPOLifecycle/Tablular/Tabs/OperatorReward.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/Tablular/Tabs/OperatorReward.tsx
@@ -20,7 +20,7 @@ const OperatorRewardTab = () => {
     size: 50
   });
 
-  const [sort, setSort] = useState<string>("");
+  const [sort, setSort] = useState<string>("time,DESC");
 
   const columns: Column<SPO_REWARD>[] = [
     {
@@ -73,6 +73,7 @@ const OperatorRewardTab = () => {
     <Box>
       <Table
         {...fetchData}
+        defaultSort="time,DESC"
         columns={columns}
         total={{
           title: "Pool Registration",


### PR DESCRIPTION
## Description

add default sort in operator reward by timestamp

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/b3169314-f55f-4bcd-8ccc-d87686373c9c)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/93ce971b-d311-4fad-bd28-
6c6073820c11)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)