### PR TITLE
Fix: MET-1296 Flow Sign in Sign up

### DIFF
--- a/src/pages/ForgotPassword/index.tsx
+++ b/src/pages/ForgotPassword/index.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useReducer, useRef, useState } from "react";
 import { Box, FormGroup } from "@mui/material";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
+import { HiArrowLongLeft } from "react-icons/hi2";
+import { IoMdClose } from "react-icons/io";
 
 import { EmailIcon } from "src/commons/resources";
 import { routers } from "src/commons/routers";
@@ -8,6 +10,9 @@ import { forgotPassword } from "src/commons/utils/userRequest";
 
 import {
   AlertCustom,
+  BackButton,
+  BackText,
+  CloseButton,
   Container,
   FormHelperTextCustom,
   InputCustom,
@@ -78,6 +83,13 @@ export default function ForgotPassword() {
     });
   };
 
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+  }, []);
+
   const handleKeyDown = (event: any) => {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -135,6 +147,14 @@ export default function ForgotPassword() {
     return;
   };
 
+  const handleRedirect = (forceGoHome?: boolean) => {
+    if (forceGoHome) {
+      history.replace(routers.HOME);
+    } else {
+      history.replace(routers.SIGN_IN);
+    }
+  };
+
   return (
     <Container>
       <WrapContent>
@@ -150,6 +170,13 @@ export default function ForgotPassword() {
                   <AlertCustom severity="error">Invalid email information.</AlertCustom>
                 </Box>
               ) : null}
+              <BackButton onClick={() => handleRedirect()}>
+                <HiArrowLongLeft fontSize="16px" />
+                <BackText>Back</BackText>
+              </BackButton>
+              <CloseButton saving={0} onClick={() => handleRedirect(true)}>
+                <IoMdClose />
+              </CloseButton>
               <WrapInput>
                 <Label>Email</Label>
                 <InputCustom
@@ -162,7 +189,6 @@ export default function ForgotPassword() {
                   inputRef={emailInputRef}
                   value={formData.email.value}
                   onChange={handleChange}
-                  onKeyDown={handleKeyDown}
                   onBlur={checkError}
                   fullWidth
                   placeholder="Email"

--- a/src/pages/ForgotPassword/styles.ts
+++ b/src/pages/ForgotPassword/styles.ts
@@ -1,3 +1,4 @@
+import { IconButton } from "@mui/material";
 import { Alert, Box, Button, Divider, FormHelperText, Input, styled } from "@mui/material";
 
 import { User2RC } from "src/commons/resources";
@@ -43,6 +44,7 @@ export const WrapForm = styled(Box)(({ theme }) => ({
   borderRadius: "12px",
   display: "flex",
   flexDirection: "column",
+  position: "relative",
   gap: "25px",
   width: "min(80vw,420px)",
   padding: "35px 40px 40px",
@@ -155,5 +157,40 @@ export const AlertCustom = styled(Alert)`
   background: "#FFF7F7";
   ${({ theme }) => theme.breakpoints.down("sm")} {
     font-size: 12px;
+  }
+`;
+
+export const BackButton = styled(Box)(({ theme }) => ({
+  display: "inline-flex",
+  textAlign: "left",
+  alignItems: "center",
+  gap: "10px",
+  marginBottom: "10px",
+  cursor: "pointer",
+  position: "absolute",
+  top: "15px",
+  left: "25px",
+  [theme.breakpoints.down("md")]: {
+    top: "10px",
+    left: "12px"
+  }
+}));
+
+export const BackText = styled("small")`
+  color: ${(props) => props.theme.palette.grey[400]};
+  font-weight: var(--font-weight-bold);
+`;
+
+export const CloseButton = styled(IconButton) <{ saving: number }>`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid ${(props) => props.theme.palette.grey["A100"]};
+  cursor: ${(props) => (props.saving ? `wait` : `pointer`)};
+  &:hover {
+    ${(props) => (props.saving ? `background: none;` : ``)}
   }
 `;

--- a/src/pages/ResetPassword/index.tsx
+++ b/src/pages/ResetPassword/index.tsx
@@ -134,6 +134,13 @@ export default function ResetPassword() {
     }
   };
 
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+  }, []);
+
   const handleKeyDown = (event: any) => {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -179,7 +186,6 @@ export default function ResetPassword() {
                     </Box>
                   }
                   name="password"
-                  onKeyDown={handleKeyDown}
                   endAdornment={
                     <InputAdornment position="end">
                       <IconButton aria-label="toggle password visibility" onClick={handleTogglePassword}>
@@ -206,7 +212,6 @@ export default function ResetPassword() {
                     </Box>
                   }
                   fullWidth
-                  onKeyDown={handleKeyDown}
                   name="confirmPassword"
                   onChange={handleChange}
                   type={showConfirmPassword ? "text" : "password"}

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -123,6 +123,13 @@ export default function SignIn() {
     }
   };
 
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+  }, []);
+
   const getError = (name: string, value: string) => {
     let error = "";
     switch (name) {
@@ -237,7 +244,6 @@ export default function SignIn() {
                 name="email"
                 value={formData.email.value}
                 onChange={handleChange}
-                onKeyDown={handleKeyDown}
                 fullWidth
                 placeholder="Email Address"
               />
@@ -255,7 +261,6 @@ export default function SignIn() {
                 }
                 fullWidth
                 name="password"
-                onKeyDown={handleKeyDown}
                 value={formData.password.value}
                 endAdornment={
                   <InputAdornment position="end">

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Checkbox, FormControlLabel, FormGroup, IconButton, InputAdornment } from "@mui/material";
 import { useEffect, useReducer, useRef, useState } from "react";
+import { HiArrowLongLeft } from "react-icons/hi2";
 import { IoMdClose } from "react-icons/io";
 import { useHistory } from "react-router-dom";
 
@@ -9,6 +10,8 @@ import { routers } from "src/commons/routers";
 import { signUp } from "src/commons/utils/userRequest";
 
 import {
+  BackButton,
+  BackText,
   CloseButton,
   Container,
   ForgotPassword,
@@ -193,16 +196,19 @@ export default function SignUp() {
     });
   };
 
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+  }, []);
+
   const handleKeyDown = (event: any) => {
     if (event.key === 'Enter') {
       event.preventDefault();
       handleSubmit(event);
     }
   };
-
-  function handleClose() {
-    history.push(routers.HOME);
-  }
 
   const handleSubmit = (event: any) => {
     event.preventDefault();
@@ -273,17 +279,30 @@ export default function SignUp() {
       setLoading(false);
     }
   };
+
+  const handleRedirect = (forceGoHome?: boolean) => {
+    if (forceGoHome) {
+      history.replace(routers.HOME);
+    } else {
+      history.replace(routers.SIGN_IN);
+    }
+  };
+
   return (
     <Container>
       {!success ? (
         <WrapContent>
           <WrapTitle>Sign up</WrapTitle>
           <WrapHintText>
-            Already have an account? <WrapSignUp onClick={() => history.push(routers.SIGN_IN)}>Sign In Here</WrapSignUp>
+            Already have an account? <WrapSignUp onClick={() => handleRedirect()}>Sign In Here</WrapSignUp>
           </WrapHintText>
           <FormGroup>
             <WrapForm>
-              <CloseButton saving={0} onClick={() => handleClose()}>
+              <BackButton onClick={() => handleRedirect()}>
+                <HiArrowLongLeft fontSize="16px" />
+                <BackText>Back</BackText>
+              </BackButton>
+              <CloseButton saving={0} onClick={() => handleRedirect(true)}>
                 <IoMdClose />
               </CloseButton>
               <WrapInput>
@@ -296,7 +315,6 @@ export default function SignUp() {
                     </Box>
                   }
                   fullWidth
-                  onKeyDown={handleKeyDown}
                   value={formData.email.value}
                   name="email"
                   onChange={handleChange}
@@ -315,7 +333,6 @@ export default function SignUp() {
                       <EmailIcon />
                     </Box>
                   }
-                  onKeyDown={handleKeyDown}
                   fullWidth
                   value={formData.confirmEmail.value}
                   name="confirmEmail"
@@ -344,7 +361,6 @@ export default function SignUp() {
                       </IconButton>
                     </InputAdornment>
                   }
-                  onKeyDown={handleKeyDown}
                   name="password"
                   onChange={handleChange}
                   error={Boolean(formData.password.error && formData.password.touched)}
@@ -372,7 +388,6 @@ export default function SignUp() {
                     </InputAdornment>
                   }
                   name="confirmPassword"
-                  onKeyDown={handleKeyDown}
                   onChange={handleChange}
                   error={Boolean(formData.confirmPassword.error && formData.confirmPassword.touched)}
                   placeholder="Confirm Password"

--- a/src/pages/SignUp/styles.ts
+++ b/src/pages/SignUp/styles.ts
@@ -179,3 +179,24 @@ export const FormHelperTextCustom = styled(FormHelperText)`
   font-size: 14px
   line-height: 16px;
 `;
+
+export const BackButton = styled(Box)(({ theme }) => ({
+  display: "inline-flex",
+  textAlign: "left",
+  alignItems: "center",
+  gap: "10px",
+  marginBottom: "10px",
+  cursor: "pointer",
+  position: "absolute",
+  top: "15px",
+  left: "25px",
+  [theme.breakpoints.down("md")]: {
+    top: "10px",
+    left: "12px"
+  }
+}));
+
+export const BackText = styled("small")`
+  color: ${(props) => props.theme.palette.grey[400]};
+  font-weight: var(--font-weight-bold);
+`;


### PR DESCRIPTION
## Description

Fix Flow sign in Sign up

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1296](https://cardanofoundation.atlassian.net/browse/MET-1296)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
|Before|After|
|--|--|
|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/2eaa2fd1-8879-4cd4-9534-06481fb4811b)|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/cd419f93-0881-4042-8bfd-e422e87164cd)|
|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/9e5e2925-6dba-43d7-87ab-a168d0e835ca)|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/fcb40b37-fc77-4969-aa80-33e359ea08a2)|



#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1296]: https://cardanofoundation.atlassian.net/browse/MET-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ