### PR TITLE
Fix: MET-1297 Bg color Sign in screen

### DIFF
--- a/src/pages/ForgotPassword/styles.ts
+++ b/src/pages/ForgotPassword/styles.ts
@@ -4,7 +4,7 @@ import { User2RC } from "src/commons/resources";
 
 export const Container = styled(Box)`
   display: flex;
-  background-color: ${({ theme }) => theme.palette.grey[200]};
+  background-color: ${({ theme }) => theme.palette.background.default};
   justify-content: center;
   align-items: center;
   min-height: 100vh;

--- a/src/pages/ResetPassword/styles.ts
+++ b/src/pages/ResetPassword/styles.ts
@@ -4,7 +4,7 @@ import { User2RC } from "src/commons/resources";
 
 export const Container = styled(Box)`
   display: flex;
-  background-color: ${({ theme }) => theme.palette.grey[200]};
+  background-color: ${({ theme }) => theme.palette.background.default};
   min-height: 100vh;
   min-width: 100vw;
   padding: 30px 0;

--- a/src/pages/SignIn/styles.ts
+++ b/src/pages/SignIn/styles.ts
@@ -4,7 +4,7 @@ import { User2RC } from "src/commons/resources";
 
 export const Container = styled(Box)`
   display: flex;
-  background-color: ${({ theme }) => theme.palette.grey[200]};
+  background-color: ${({ theme }) => theme.palette.background.default};
   justify-content: center;
   align-items: center;
   min-height: 100vh;

--- a/src/pages/SignUp/styles.ts
+++ b/src/pages/SignUp/styles.ts
@@ -4,7 +4,7 @@ import { User2RC } from "src/commons/resources";
 
 export const Container = styled(Box)`
   display: flex;
-  background-color: ${({ theme }) => theme.palette.grey[200]};
+  background-color: ${({ theme }) => theme.palette.background.default};
   min-height: 100vh;
   min-width: 100vw;
   justify-content: center;

--- a/src/pages/VerifyEmail/styles.ts
+++ b/src/pages/VerifyEmail/styles.ts
@@ -4,7 +4,7 @@ import { User2RC } from "src/commons/resources";
 
 export const Container = styled(Box)`
   display: flex;
-  background-color: ${({ theme }) => theme.palette.grey[200]};
+  background-color: ${({ theme }) => theme.palette.background.default};
   min-height: 100vh;
   min-width: 100vw;
   justify-content: center;


### PR DESCRIPTION
## Description

Fix background color of sign in/up/forgotpassword screen

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1297](https://cardanofoundation.atlassian.net/browse/MET-1297)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/f8327c68-c634-4ee6-aee4-8f82efca3eb8)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/e010f880-2c56-4a9f-972c-23aec5f26137)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1297]: https://cardanofoundation.atlassian.net/browse/MET-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ