### PR TITLE
Fix: MEt-1287 Finding 1 Increse touch area of collapse icon Side bar

### DIFF
--- a/src/components/commons/Layout/Sidebar/SidebarMenu/styles.ts
+++ b/src/components/commons/Layout/Sidebar/SidebarMenu/styles.ts
@@ -101,7 +101,7 @@ export const FooterMenuContainer = styled(Box)(({ theme }) => ({
 export const IconMenu = styled(Box)(() => ({
   position: "absolute",
   zIndex: 10,
-  top: "50%",
+  top: "55%",
   left: "210px",
   transform: "translate(0, -50%)"
 }));

--- a/src/components/commons/Layout/index.tsx
+++ b/src/components/commons/Layout/index.tsx
@@ -3,14 +3,14 @@ import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 
-import { setOnDetailView, setSidebar } from "src/stores/user";
 import { RootState } from "src/stores/types";
+import { setOnDetailView, setSidebar } from "src/stores/user";
 
-import Header from "./Header";
-import Footer from "./Footer";
-import Sidebar from "./Sidebar";
-import { Drawer, Layout, ToggleMenu, Main, BackDrop, MainContainer, ArrowCollapse } from "./styles";
 import CustomTooltip from "../CustomTooltip";
+import Footer from "./Footer";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { ArrowCollapse, BackDrop, Drawer, Layout, Main, MainContainer, ToggleMenu, WrapIcon } from "./styles";
 
 interface Props {
   children: React.ReactNode;
@@ -37,8 +37,12 @@ const CustomLayout: React.FC<Props> = ({ children }) => {
       <BackDrop isShow={+sidebar} onClick={handleToggle} />
       <Drawer variant="permanent" open={sidebar} ModalProps={{ keepMounted: true }}>
         <CustomTooltip placement="right" title={sidebar ? `Collapse` : `Expand`}>
-          <ToggleMenu onClick={handleToggle} type="button">
-            <ArrowCollapse> {sidebar ? <FaArrowLeft /> : <FaArrowRight />}</ArrowCollapse>
+          <ToggleMenu type="button">
+            <WrapIcon onClick={handleToggle}>
+              <ArrowCollapse>
+                {sidebar ? <FaArrowLeft /> : <FaArrowRight />}
+              </ArrowCollapse>
+            </WrapIcon>
           </ToggleMenu>
         </CustomTooltip>
         <Sidebar />

--- a/src/components/commons/Layout/styles.ts
+++ b/src/components/commons/Layout/styles.ts
@@ -151,6 +151,17 @@ export const ToggleMenu = styled("button")`
   }
 `;
 
+export const WrapIcon = styled(Box)`
+  top: -9px;
+  left: -8px;
+  width: 40px;
+  height: 40px;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const MainContainer = styled(Box)`
   width: 100%;
 `;


### PR DESCRIPTION
## Description

Please include a summary of the changes and a brief description about this PR

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1287](https://cardanofoundation.atlassian.net/browse/MET-1287)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1287]: https://cardanofoundation.atlassian.net/browse/MET-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ