### PR TITLE
fix: MET-305 delegator registration recent filter reset error

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/Registration/RecentRegistrations/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/Registration/RecentRegistrations/index.tsx
@@ -46,13 +46,6 @@ const RecentRegistrations: React.FC<Props> = ({ onSelect, params, setParams, set
   }, [initialized]);
 
   useEffect(() => {
-    const isNoFilter = !params?.fromDate && !params?.toDate && !params?.txHash && !params?.sort;
-    if (initialized && data.length === 1 && isNoFilter) {
-      history.push(details.staking(stakeId, "timeline", "registration", data?.[0]?.txHash));
-    }
-  }, [params, txHash]);
-
-  useEffect(() => {
     const currentItem = data.find((item) => item.txHash === txHash);
     onSelect(currentItem || null);
   }, [txHash, data]);


### PR DESCRIPTION
## Description

Fix bug auto navigate when click reset filter in delegator registration.

Reason: When user clears filter, data is not ready update from call api. So isNoFilter is "true" but data.length is 1 (waiting for response from api) and this useEffect will navigate to detailed registration hash.
In useUpdateEffect, I use "data" for check isNoFilter because data will update after filter "params".

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/7ae9d552-d40e-453f-a849-312d9596fe6b)

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-305](https://cardanofoundation.atlassian.net/browse/MET-305)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

Video:
https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/64d58d89-ffdc-4286-8c97-cd96042892cc

##### _After_

Video:
https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/09c2d968-d60b-41ea-8851-0318c12e3cb6

#### Safari
##### _Before_

No change

##### _After_

No change

#### Responsive
##### _Before_

No change

##### _After_

No change

[MET-305]: https://cardanofoundation.atlassian.net/browse/MET-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ