### PR TITLE
test:MET-1165 Update Unit test for Epochs

### DIFF
--- a/src/components/EpochDetail/EpochBlockList/EpochBlockList.test.tsx
+++ b/src/components/EpochDetail/EpochBlockList/EpochBlockList.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "src/test-utils";
+import useFetchList from "src/commons/hooks/useFetchList";
+
+import EpochBlockList from "./index";
+
+jest.mock("src/commons/hooks/useFetchList");
+
+const mockedData = [
+  {
+    blockNo: 8904653,
+    epochNo: 417,
+    epochSlotNo: 431977,
+    hash: "d7640c234c32dbfbe5a69c8e78728121a7a4f28469a9f94e78ff26ec0f096fe1",
+    slotLeader: "a503e42a2c6ef347d834fa404fa4d4bfa6dfb48256ff95b067483980",
+    slotNo: 95212777,
+    time: "2023/06/14 21:44:28",
+    totalFees: 10775536,
+    totalOutput: 27326434270526,
+    txCount: 29
+  }
+];
+describe("EpochBlockList component", () => {
+  it("should render component on PC", () => {
+    const mockedUseFetchList = useFetchList as jest.Mock;
+    mockedUseFetchList.mockReturnValue({
+      data: mockedData
+    });
+    render(<EpochBlockList epochId="417" />);
+    expect(screen.getByText("Transactions")).toBeInTheDocument();
+    expect(screen.getByText("Block")).toBeInTheDocument();
+    expect(screen.getByText("Slot")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
+  });
+
+  it("should component render the empty table", () => {
+    const mockedUseFetchList = useFetchList as jest.Mock;
+    mockedUseFetchList.mockReturnValue({
+      data: [],
+      error: true
+    });
+    render(<EpochBlockList epochId="417" />);
+    expect(screen.getByAltText("no data")).toBeInTheDocument();
+  });
+});

--- a/src/components/EpochDetail/EpochOverview/EpochOverview.test.tsx
+++ b/src/components/EpochDetail/EpochOverview/EpochOverview.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "src/test-utils";
+
+import EpochOverview from "./index";
+
+const mockedData: IDataEpoch = {
+  blkCount: 20947,
+  endTime: "2023/06/14 21:44:28",
+  maxSlot: 432000,
+  no: 417,
+  outSum: 229341415829835740,
+  rewardsDistributed: 0,
+  startTime: "2023/06/09 21:47:26",
+  status: "REWARDING",
+  txCount: 375738,
+  epochSlotNo: 0
+};
+
+describe("EpochOverview", () => {
+  it("should render on PC", () => {
+    render(<EpochOverview data={mockedData} lastUpdated={1} loading={false} />);
+    expect(screen.getByText("06/15/2023 04:44:28")).toBeInTheDocument();
+    expect(screen.getByText("06/10/2023 04:47:26")).toBeInTheDocument();
+    expect(screen.getByText("417")).toBeInTheDocument();
+  });
+
+  it("should show loading state", () => {
+    const { container } = render(<EpochOverview data={mockedData} lastUpdated={1} loading={true} />);
+    expect(screen.queryByText("06/15/2023 04:44:28")).not.toBeInTheDocument();
+    expect(screen.queryByText("06/10/2023 04:47:26")).not.toBeInTheDocument();
+    expect(screen.queryByText("417")).not.toBeInTheDocument();
+    expect(container.getElementsByClassName("MuiSkeleton-root").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/commons/DetailView/DetailViewEpoch.test.tsx
+++ b/src/components/commons/DetailView/DetailViewEpoch.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "src/test-utils";
+import useFetch from "src/commons/hooks/useFetch";
+import { formatADAFull } from "src/commons/utils/helper";
+
+import DetailViewEpoch from "./DetailViewEpoch";
+
+const mockedData = {
+  blkCount: 20947,
+  endTime: "2023/06/14 21:44:28",
+  maxSlot: 432000,
+  no: 417,
+  outSum: 229341415829835740,
+  rewardsDistributed: null,
+  startTime: "2023/06/09 21:47:26",
+  status: "REWARDING",
+  txCount: 375738
+};
+
+jest.mock("src/commons/hooks/useFetch");
+
+describe("DetailViewEpoch component", () => {
+  beforeEach(() => {
+    const mockedUseFetch = useFetch as jest.Mock;
+    mockedUseFetch.mockReturnValue({
+      data: mockedData,
+      lastUpdated: "2023/06/14 21:44:28"
+    });
+  });
+  it("rendering component on PC", () => {
+    render(<DetailViewEpoch callback={jest.fn()} epochNo={123} handleClose={jest.fn()} />);
+    expect(screen.getByText("View Details")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /20947/i })).toBeInTheDocument();
+    expect(screen.getByText(mockedData.txCount)).toBeInTheDocument();
+    expect(screen.getByText(formatADAFull(mockedData.outSum))).toBeInTheDocument();
+  });
+});

--- a/src/components/commons/Epoch/FirstEpoch/FirstEpoch.test.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/FirstEpoch.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "src/test-utils";
+
+import FirstEpoch from "./index";
+
+const mockedEpochData: IDataEpoch = {
+  blkCount: 1197,
+  endTime: "2023/06/19 21:44:54",
+  maxSlot: 432000,
+  no: 418,
+  outSum: 14328019575995152,
+  rewardsDistributed: 0,
+  startTime: "2023/06/14 21:44:54",
+  status: "IN_PROGRESS",
+  epochSlotNo: 0,
+  txCount: 0
+};
+
+describe("FirstEpoch component", () => {
+  it("rendering component on PC", () => {
+    render(<FirstEpoch data={mockedEpochData} onClick={jest.fn()} />);
+    expect(screen.getByText(new RegExp(mockedEpochData.maxSlot.toString(), "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`epoch number ${mockedEpochData.no}`, "i"))).toBeInTheDocument();
+  });
+});

--- a/src/pages/Epoch/Epoch.test.tsx
+++ b/src/pages/Epoch/Epoch.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "src/test-utils";
+import useFetchList from "src/commons/hooks/useFetchList";
+
+import Epoch from "./index";
+
+jest.mock("src/commons/hooks/useFetchList");
+const mockData = [
+  {
+    blkCount: 20947,
+    endTime: "2023/06/14 21:44:28",
+    maxSlot: 432000,
+    no: 417,
+    outSum: 229341415829835740,
+    rewardsDistributed: null,
+    startTime: "2023/06/09 21:47:26",
+    status: "REWARDING",
+    txCount: 375738
+  }
+];
+
+const mockDataLatestEpoch = [
+  {
+    blkCount: 1973,
+    endTime: "2023/06/19 21:44:54",
+    maxSlot: 432000,
+    no: 418,
+    outSum: 22150782023247476,
+    rewardsDistributed: null,
+    startTime: "2023/06/14 21:44:54",
+    status: "IN_PROGRESS",
+    txCount: 37219
+  }
+];
+
+describe("Epoch component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mockedUseFetchList = useFetchList as jest.Mock;
+
+    mockedUseFetchList.mockReturnValueOnce({
+      data: mockData,
+      currentPage: 0,
+      total: mockData.length,
+      update: jest.fn()
+    });
+
+    mockedUseFetchList.mockReturnValueOnce({
+      data: mockDataLatestEpoch,
+      currentPage: 0,
+      total: mockDataLatestEpoch.length,
+      update: jest.fn()
+    });
+  });
+
+  it("should latest epoch component render on PC", () => {
+    render(<Epoch />);
+    expect(screen.getByText("06/15/2023 04:44:54")).toBeInTheDocument();
+    expect(screen.getByText(mockDataLatestEpoch[0].blkCount)).toBeInTheDocument();
+  });
+
+  it("should epoch table render on PC", () => {
+    render(<Epoch />);
+    const result = screen.getByText(/result/i);
+
+    expect(result.innerHTML.includes("1")).toBeTruthy();
+  });
+
+  it("should epoch table got errors or empty", () => {
+    const mockedUseFetchList = useFetchList as jest.Mock;
+    mockedUseFetchList.mockReturnValueOnce({
+      data: [],
+      currentPage: 0,
+      total: 0,
+      update: jest.fn(),
+      error: true
+    });
+    mockedUseFetchList.mockReturnValueOnce({
+      data: [],
+      currentPage: 0,
+      total: 0,
+      update: jest.fn(),
+      error: true
+    });
+
+    render(<Epoch />);
+    expect(screen.getByAltText("no data")).toBeInTheDocument();
+  });
+});

--- a/src/pages/EpochDetail/EpochDetail.test.tsx
+++ b/src/pages/EpochDetail/EpochDetail.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "src/test-utils";
+import useFetch from "src/commons/hooks/useFetch";
+
+import EpochDetail from "./index";
+
+jest.mock("src/commons/hooks/useFetch");
+
+describe("EpochDetail component", () => {
+  it("should component render the empty image", () => {
+    const mockUseFetch = useFetch as jest.Mock;
+    mockUseFetch.mockReturnValue({
+      data: null,
+      initialized: true
+    });
+    render(<EpochDetail />);
+    expect(screen.getByAltText("empty icon")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Update Unit test for Epochs and related components
 
## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MEET-1165](https://cardanofoundation.atlassian.net/browse/MET-1165)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

##### _After_
<img width="209" alt="Screenshot 2023-06-19 at 09 36 10" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/181a81f9-6edf-41b2-9e46-2b00a3f29353">
<img width="197" alt="Screenshot 2023-06-19 at 09 50 16" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/d58d9ecf-8523-4024-a26e-6985a988cfab">
<img width="255" alt="Screenshot 2023-06-19 at 09 51 04" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/6133dd5b-cd9d-4d2b-932c-341fc5e33f05">
<img width="244" alt="Screenshot 2023-06-19 at 09 51 40" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/7c0489f2-1d6e-4d98-bb86-651aeb0c0186">
<img width="272" alt="Screenshot 2023-06-19 at 09 52 21" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/8320760a-9399-49ed-bacb-dbd342a73c1c">
<img width="521" alt="Screenshot 2023-06-19 at 09 52 46" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/36c8e874-8376-4c6c-8d90-c672f6066517">


