### PR TITLE
Met 1342 next and prev staking

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
@@ -69,6 +69,13 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
   }>();
   const [open, setOpen] = useState(false);
   const [openDescriptionModal, setOpenDescriptionModal] = useState(false);
+  const [tabsValid, setTabValid] = useState([
+    "hasRegistration",
+    "hasDelegation",
+    "hashRewards",
+    "hasWithdrawal",
+    "hasDeRegistration"
+  ]);
 
   useEffect(() => {
     const element = document.getElementById(`step-${currentStep}`);
@@ -76,6 +83,13 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
       element.scrollIntoView(true);
     }
   }, [currentStep]);
+
+  useEffect(() => {
+    if (tabsRenderConfig) {
+      setTabValid((prev) => prev.filter((tab) => tabsRenderConfig[tab]));
+    }
+  }, [JSON.stringify(tabsRenderConfig)]);
+
   if (!tabsRenderConfig) return null;
 
   const stepper: StepperProps[] = [
@@ -242,29 +256,77 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
           <PreviousButton
             sx={{ mb: `${isMobile ? "16px" : "0px"}` }}
             onClick={() => {
-              history.push(details.staking(stakeId, "timeline", stepper[currentStep - 1]?.key));
-              setCurrentStep(currentStep - 1);
+              history.push(
+                details.staking(
+                  stakeId,
+                  "timeline",
+                  stepper.filter(
+                    (s) =>
+                      s.keyCheckShow ===
+                      tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                  )[0]?.key
+                )
+              );
+              setCurrentStep(
+                stepper.findIndex(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                )
+              );
             }}
           >
             <PreviousIcon />
-            <ButtonText>Previous: {stepper[currentStep - 1]?.title}</ButtonText>
+            <ButtonText>
+              Previous:{" "}
+              {
+                stepper.filter(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                )[0]?.title
+              }
+            </ButtonText>
           </PreviousButton>
         ) : (
           <Box />
         )}
         <NextButton
           onClick={() => {
-            if (currentStep === stepper.length - 1) {
+            if (tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) === tabsValid.length - 1) {
               history.push(details.staking(stakeId, "tabular"));
             } else {
-              history.push(details.staking(stakeId, "timeline", stepper[currentStep + 1]?.key));
-              setCurrentStep(currentStep + 1);
+              history.push(
+                details.staking(
+                  stakeId,
+                  "timeline",
+                  stepper.filter(
+                    (s) =>
+                      s.keyCheckShow ===
+                      tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                  )[0]?.key
+                )
+              );
+              setCurrentStep(
+                stepper.findIndex(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                )
+              );
             }
           }}
           variant="contained"
         >
           <ButtonText fontSize={isMobile ? 14 : 16}>
-            Next: {currentStep === stepper.length - 1 ? "View in tabular" : stepper[currentStep + 1]?.title}
+            Next:{" "}
+            {tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) === tabsValid.length - 1
+              ? "View in tabular"
+              : stepper.filter(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                )[0]?.title}
           </ButtonText>
           <NextIcon />
         </NextButton>

--- a/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
@@ -35,9 +35,6 @@ export const NextButton = styled(Button)(({ theme }) => ({
   fontWeight: "bold",
   padding: "10px 20px",
   borderRadius: "8px",
-  position: "unset",
-  right: 20,
-  bottom: 30,
   ":hover": {
     background: alpha(theme.palette.grey[700], 0.8)
   }
@@ -48,10 +45,7 @@ export const PreviousButton = styled(Button)(({ theme }) => ({
   textTransform: "capitalize",
   fontWeight: "bold",
   borderRadius: "8px",
-  position: "unset",
   padding: "10px 20px",
-  left: 20,
-  bottom: 30,
   border: `2px solid ${theme.palette.border.hint}`,
   ":hover": {
     background: alpha(theme.palette.grey[700], 0.1)

--- a/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
@@ -60,9 +60,16 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
   const history = useHistory();
   const { isMobile } = useScreen();
   const { palette } = useTheme();
+  const [tabsValid, setTabValid] = useState(["isRegistration", "isUpdate", "isReward", "isDeRegistration"]);
   useEffect(() => {
     document.getElementById(`step-${currentStep}`)?.scrollIntoView();
   }, [currentStep]);
+
+  useEffect(() => {
+    if (renderTabsSPO) {
+      setTabValid((prev) => prev.filter((tab) => renderTabsSPO[tab]));
+    }
+  }, [JSON.stringify(renderTabsSPO)]);
 
   if (!renderTabsSPO) return null;
 
@@ -181,29 +188,75 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
         {currentStep > 0 && (
           <PreviousButton
             onClick={() => {
-              history.replace(details.spo(poolId, "timeline", stepper[currentStep - 1]?.key));
-              setCurrentStep(currentStep - 1);
+              history.replace(
+                details.spo(
+                  poolId,
+                  "timeline",
+                  stepper.filter(
+                    (s) =>
+                      s.keyCheckShow ===
+                      tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                  )[0]?.key
+                )
+              );
+              setCurrentStep(
+                stepper.findIndex(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                )
+              );
             }}
           >
             <PreviousIcon />
             <Box fontSize={isMobile ? 14 : 16} component={"span"}>
-              Previous: {stepper[currentStep - 1]?.title}
+              Previous:{" "}
+              {
+                stepper.filter(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) - 1]
+                )[0]?.title
+              }
             </Box>
           </PreviousButton>
         )}
         <NextButton
           onClick={() => {
-            if (currentStep === stepper.length - 1) {
+            if (tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) === tabsValid.length - 1) {
               history.push(details.spo(poolId, "tabular"));
             } else {
-              history.replace(details.spo(poolId, "timeline", stepper[currentStep + 1]?.key));
-              setCurrentStep(currentStep + 1);
+              history.replace(
+                details.spo(
+                  poolId,
+                  "timeline",
+                  stepper.filter(
+                    (s) =>
+                      s.keyCheckShow ===
+                      tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                  )[0]?.key
+                )
+              );
+              setCurrentStep(
+                stepper.findIndex(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                )
+              );
             }
           }}
           variant="contained"
         >
           <ButtonText>
-            Next: {currentStep === stepper.length - 1 ? "View in tabular" : stepper[currentStep + 1]?.title}
+            Next:{" "}
+            {tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) === tabsValid.length - 1
+              ? "View in tabular"
+              : stepper.filter(
+                  (s) =>
+                    s.keyCheckShow ===
+                    tabsValid[tabsValid.findIndex((t) => t === stepper[currentStep].keyCheckShow) + 1]
+                )[0]?.title}
           </ButtonText>
           <NextIcon />
         </NextButton>

--- a/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
@@ -65,7 +65,6 @@ export const PreviousButton = styled(Button)(({ theme }) => ({
   textTransform: "capitalize",
   fontWeight: "bold",
   padding: "8px 20px",
-  position: "unset",
   borderRadius: "8px",
   border: `2px solid ${theme.palette.border.hint}`,
   ":hover": {

--- a/src/pages/DelegatorLifecycle/index.tsx
+++ b/src/pages/DelegatorLifecycle/index.tsx
@@ -62,7 +62,14 @@ const DelegatorLifecycle = () => {
     tablular: null
   };
 
-  const validTab: DelegationStep = tabList[tab] >= 0 ? tab : "registration";
+  const tabsValid = {
+    registration: "hasRegistration",
+    delegation: "hasDelegation",
+    rewards: "hashRewards",
+    "withdrawal-history": "hasWithdrawal",
+    deregistration: "hasDeRegistration"
+  };
+  let validTab: DelegationStep = tabList[tab] >= 0 ? tab : "registration";
   const validMode: ViewMode = MODES.find((item) => item === mode) || "timeline";
 
   const [currentStep, setCurrentStep] = useState(tabList[validTab]);
@@ -78,9 +85,15 @@ const DelegatorLifecycle = () => {
   );
 
   useEffect(() => {
-    setCurrentStep(tabList[validTab]);
+    if (listTabs && listTabs[tabsValid[tab]]) {
+      setCurrentStep(tabList[validTab]);
+      return;
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validTab]);
+    validTab = "registration";
+    setCurrentStep(tabList["registration"]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listTabs]);
 
   useEffect(() => {
     document.title = `Staking Delegation Lifecycle ${stakeId} | Cardano Explorer`;

--- a/src/pages/SPOLifecycle/index.tsx
+++ b/src/pages/SPOLifecycle/index.tsx
@@ -66,11 +66,18 @@ const SPOLifecycle = () => {
     tablular: null
   };
 
+  const tabsValid = {
+    registration: "isRegistration",
+    "pool-updates": "isUpdate",
+    "operator-rewards": "isReward",
+    deregistration: "isDeRegistration"
+  };
+
   const { data, error, initialized } = useFetch<PoolInfo>(poolId ? API.SPO_LIFECYCLE.POOL_INFO(poolId) : "");
   const { data: renderTabsSPO, loading: loadingListTabs } = useFetch<ListTabResponseSPO>(
     API.SPO_LIFECYCLE.TABS(poolId)
   );
-  const validTab: SPOStep = tabList[tab] >= 0 ? tab : "registration";
+  let validTab: SPOStep = tabList[tab] >= 0 ? tab : "registration";
   const validMode: ViewMode = MODES.find((item) => item === mode) || "timeline";
 
   const [currentStep, setCurrentStep] = useState(tabList[validTab]);
@@ -78,9 +85,15 @@ const SPOLifecycle = () => {
   const { isLoggedIn } = useAuth();
 
   useEffect(() => {
-    setCurrentStep(tabList[validTab]);
+    if (renderTabsSPO && renderTabsSPO[tabsValid[tab]]) {
+      setCurrentStep(tabList[validTab]);
+      return;
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validTab]);
+    validTab = "registration";
+    setCurrentStep(tabList["registration"]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderTabsSPO]);
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef(null);


### PR DESCRIPTION
## Description

Next and prev button click can access tab disnable
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-1342)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
**SPO lifecycle**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/e9cb9a85-88a2-47fa-8674-3d4758707c98)
**Delegator lifecycle**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/339e2281-9439-4764-b221-1ae62b4cdd9d)

##### _After_
**SPO lifecycle**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/54af77f5-d20f-4948-bbc6-4a064aeea497)
**Delegator lifecycle**
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/1d804cd8-23fc-4ddf-9a5a-849af75566eb)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)