### PR TITLE
fix: MET-615 display no record overflow

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/ADATransferModal/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/ADATransferModal/index.tsx
@@ -9,7 +9,7 @@ import { useScreen } from "src/commons/hooks/useScreen";
 
 import WalletActivity from "./WalletActivity";
 import RewardActivity from "./RewardActivity";
-import { CustomTab, StyledTab, StyledTabs } from "./styles";
+import { CustomTab, StyledBox, StyledTab, StyledTabs } from "./styles";
 
 interface IProps {
   open: boolean;
@@ -45,9 +45,10 @@ const ADATransferModal: React.FC<IProps> = ({ open, handleCloseModal }) => {
       handleCloseModal={handleCloseModal}
       width={1200}
       height={isMobile ? "73vh" : isTablet ? "67vh" : "72vh"}
+      modalStyle={{ overflow: "hidden" }}
     >
       <TabContext value={activityType}>
-        <Box overflow={!isGalaxyFoldSmall ? "auto" : "hidden"} maxHeight={isMobile ? "80vh" : "70vh"}>
+        <StyledBox overflow={!isGalaxyFoldSmall ? "auto" : "hidden"}>
           <StyledTabs
             value={activityType}
             onChange={onChangeTab}
@@ -91,7 +92,7 @@ const ADATransferModal: React.FC<IProps> = ({ open, handleCloseModal }) => {
           <TabPanel value={ActivityType.REWARDS} style={{ padding: 0, paddingTop: 12 }}>
             <RewardActivity />
           </TabPanel>
-        </Box>
+        </StyledBox>
       </TabContext>
     </StyledModal>
   );

--- a/src/components/StakingLifeCycle/DelegatorLifecycle/ADATransferModal/styles.ts
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/ADATransferModal/styles.ts
@@ -117,3 +117,18 @@ export const StyledBoxTransaction = styled("div")(({ theme }) => ({
     maxWidth: "195px"
   }
 }));
+export const StyledBox = styled(Box)(({ theme }) => ({
+  maxHeight: "70vh",
+  "&::-webkit-scrollbar": {
+    background: "transparent"
+  },
+  "&::-webkit-scrollbar-track": {
+    background: "transparent"
+  },
+  "&::-webkit-scrollbar-thumb": {
+    background: "transparent"
+  },
+  [theme.breakpoints.down("sm")]: {
+    maxHeight: "80vh"
+  }
+}));

--- a/src/components/commons/StyledModal/index.tsx
+++ b/src/components/commons/StyledModal/index.tsx
@@ -13,6 +13,7 @@ interface IProps extends ModalProps {
   paddingX?: number | string;
   paddingY?: number | string;
   contentStyle?: SxProps;
+  modalStyle?: SxProps;
 }
 const StyledModal: React.FC<IProps> = ({
   open,
@@ -23,7 +24,8 @@ const StyledModal: React.FC<IProps> = ({
   height,
   paddingX,
   paddingY,
-  contentStyle = {}
+  contentStyle = {},
+  modalStyle = {}
 }) => {
   const { isMobile } = useScreen();
 
@@ -35,6 +37,7 @@ const StyledModal: React.FC<IProps> = ({
         paddingX={paddingX || (isMobile ? "10px" : "40px")}
         paddingY={paddingY || (isMobile ? "20px" : "50px")}
         viewwidth={isMobile ? 92 : 70}
+        sx={modalStyle}
       >
         <CloseButton saving={0} onClick={() => handleCloseModal()} data-testid="close-modal-button">
           <IoMdClose />


### PR DESCRIPTION
## Description

Display no record overflow in device fold 2 open

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9c675489-2126-43ab-b060-5673401a1f98)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/2f5eb5aa-00b2-4aa1-a917-18dc3cc54901)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9c675489-2126-43ab-b060-5673401a1f98)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/2f5eb5aa-00b2-4aa1-a917-18dc3cc54901)


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ