### PR TITLE
Fix: MET-1268 Split Fees Column

### DIFF
--- a/src/components/DelegationDetail/DelegationDetailOverview/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailOverview/index.tsx
@@ -13,10 +13,10 @@ interface IDelegationDetailOverview {
 const DelegationDetailOverview: React.FC<IDelegationDetailOverview> = ({ data, loading }) => {
   const overviewData = {
     Reward: `${data?.reward || 0}%`,
-    Fee: formatPercent(data?.margin),
+    Margin: formatPercent(data?.margin),
     ROS: formatPercent(data?.ros ? data?.ros / 100 : 0),
     "Pledge(A)": formatADAFull(data?.pledge),
-    "Cost(A)": formatADAFull(data?.cost),
+    "Fee(A)": formatADAFull(data?.cost),
     "Epoch Block": data?.epochBlock || 0,
     "Lifetime Block": numberWithCommas(data?.lifetimeBlock)
   };

--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -60,10 +60,16 @@ const DelegationLists: React.FC = () => {
       render: (r) => <RateWithIcon value={r.reward} multiple={1} />
     },
     {
+      title: "Margin ",
+      key: "margin",
+      minWidth: "120px",
+      render: (r) => `${formatPercent(r.feePercent)}`,
+    },
+    {
       title: "Fee (A) ",
       key: "pu.fixedCost",
       minWidth: "120px",
-      render: (r) => `${formatPercent(r.feePercent)} (${formatADAFull(r.feeAmount)} A)`,
+      render: (r) => `${formatADAFull(r.feeAmount)} A`,
       sort: ({ columnKey, sortValue }) => {
         sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
       }

--- a/src/components/Home/TopDelegationPools/index.tsx
+++ b/src/components/Home/TopDelegationPools/index.tsx
@@ -52,12 +52,23 @@ const TopDelegationPools = () => {
       render: (r) => <RateWithIcon value={r.reward} multiple={1} />
     },
     {
-      title: "Fee (A)",
-      key: "fee",
+      title: "Margin",
+      key: "feePercent",
       render: (r) => (
-        <CustomTooltip title={`${r.feePercent * 100 || 0}% (${formatADAFull(r.feeAmount)} A)`}>
+        <CustomTooltip title={`${r.feePercent * 100 || 0}%`}>
           <Box display="inline-block">
-            {formatPercent(r.feePercent || 0)} ({formatADAFull(r.feeAmount)} A)
+            {formatPercent(r.feePercent || 0)}
+          </Box>
+        </CustomTooltip>
+      )
+    },
+    {
+      title: "Fee (A)",
+      key: "feeAmount",
+      render: (r) => (
+        <CustomTooltip title={`${formatADAFull(r.feeAmount)} A`}>
+          <Box display="inline-block">
+            {formatADAFull(r.feeAmount)} A
           </Box>
         </CustomTooltip>
       )


### PR DESCRIPTION
## Description

Split Fees Column pool to Margin and Fee(A)

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1268](https://cardanofoundation.atlassian.net/browse/MET-1268)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
|Before|After|
|--|--|
|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/9962a8f3-63cd-4f44-9b2f-bf41d0bdccf0)|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/44c959e2-d297-4a78-85ef-b912006f458a)|
|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/d436ba0d-c0b7-4b67-87d2-06e4c80d9121)|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/455741c4-0794-4ea0-9519-be2e3de361db)|
|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/70e37a7e-608f-423c-9ad0-9ff22583b158)|![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/ed5e1b2e-c3e0-4553-b4e3-ac7d0a7652de)|

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1268]: https://cardanofoundation.atlassian.net/browse/MET-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ