### PR TITLE
fix: display wrong name tab in report detail

### DIFF
--- a/src/components/ReportGeneratedStakingDetail/index.tsx
+++ b/src/components/ReportGeneratedStakingDetail/index.tsx
@@ -51,7 +51,7 @@ const stackeTabs: ITab[] = [
   },
   {
     icon: RewardsDistributionIcon,
-    label: "Operator Rewards",
+    label: "Rewards Distribution",
     key: "rewards",
     mappingKey: "Rewards",
     component: <RewardsDistributionTab />


### PR DESCRIPTION
## Description

Display wrong name tab in report detail

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a49ab6e7-de12-404e-92c1-fb977c6efb31)
##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/e31f3393-7f2d-4d75-8c3e-9217d98eabb8)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/252926f4-17e3-4aea-95d1-b6fa730cb8c1)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/2fe3ad30-6be2-4a87-b6e5-1747c32880f4)