### PR TITLE
fix:  no display full name token when hover with long name token

### DIFF
--- a/src/components/commons/DetailHeader/index.tsx
+++ b/src/components/commons/DetailHeader/index.tsx
@@ -197,10 +197,10 @@ const DetailHeader: React.FC<DetailHeaderProps> = (props) => {
                   ? currentEpoch && (epoch?.no || 0) === currentEpoch?.no
                     ? ((moment(formatDateTimeLocal(epoch?.endTime || "")).diff(moment()) > 0 &&
                       epoch?.slot < MAX_SLOT_EPOCH
-                      ? epoch?.slot
-                      : MAX_SLOT_EPOCH) /
-                      MAX_SLOT_EPOCH) *
-                    100
+                        ? epoch?.slot
+                        : MAX_SLOT_EPOCH) /
+                        MAX_SLOT_EPOCH) *
+                      100
                     : 100
                   : (epoch?.slot / MAX_SLOT_EPOCH) * 100
               }
@@ -283,9 +283,11 @@ const DetailHeader: React.FC<DetailHeaderProps> = (props) => {
                           }}
                           key={index}
                         >
-                          <Box mr={2} sx={{ maxWidth: "120px", textOverflow: "ellipsis", overflow: "hidden" }}>
-                            {item.assetName}
-                          </Box>
+                          <CustomTooltip title={item.assetName}>
+                            <Box mr={2} sx={{ maxWidth: "120px", textOverflow: "ellipsis", overflow: "hidden" }}>
+                              {item.assetName}
+                            </Box>
+                          </CustomTooltip>
                           <Box fontWeight={500}>{numberWithCommas(item.assetQuantity)}</Box>
                         </StyledMenuItem>
                       ))}


### PR DESCRIPTION
## Description

No display full name token when hover with long name token

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3167c72e-8e55-4d85-8ca7-79f244521d15)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6b437aeb-221e-4528-96c0-9bcd3778e181)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3167c72e-8e55-4d85-8ca7-79f244521d15)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6b437aeb-221e-4528-96c0-9bcd3778e181)