### PR TITLE
fix: not navigate to epoch detail when click epoch number inprogess

### DIFF
--- a/src/components/commons/Epoch/FirstEpoch/index.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/index.tsx
@@ -1,11 +1,13 @@
 import { Box } from "@mui/material";
 import { useSelector } from "react-redux";
 import moment from "moment";
+import { useHistory } from "react-router-dom";
 
 import { ExchangeIcon, cubeIconUrl, slotIconUrl, timeIconUrl } from "src/commons/resources";
 import { EPOCH_STATUS, MAX_SLOT_EPOCH } from "src/commons/utils/constants";
 import { formatDateTimeLocal } from "src/commons/utils/helper";
 import { Status } from "src/pages/Epoch/styles";
+import { details } from "src/commons/routers";
 
 import { Container, Content, EpochNumber, EpochProgress, SubContent, TitleCard } from "./styles";
 import ProgressCircle from "../../ProgressCircle";
@@ -18,6 +20,11 @@ interface IProps {
 
 export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) {
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
+  const history = useHistory();
+  const handleClick = (e: React.SyntheticEvent<EventTarget>): void => {
+    e?.stopPropagation();
+    history.push(details.epoch(currentEpochData.no || 0));
+  };
   if (!currentEpochData) return null;
   const progress =
     moment(formatDateTimeLocal(currentEpochData.endTime)).diff(moment()) >= 0
@@ -29,7 +36,7 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
       hideHeader: true,
       title: <EpochNumber>{currentEpochData?.no}</EpochNumber>,
       value: (
-        <Box display={"flex"} alignItems="center" justifyContent={"center"}>
+        <Box display={"flex"} alignItems="center" justifyContent={"center"} onClick={handleClick}>
           <ProgressCircle
             size={100}
             pathLineCap="butt"
@@ -39,9 +46,7 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
             trailOpacity={1}
           >
             <EpochProgress>{`${progress}%`}</EpochProgress>
-            <Status status={currentEpochData?.status?.toLowerCase()}>
-              {EPOCH_STATUS[currentEpochData?.status]}
-            </Status>
+            <Status status={currentEpochData?.status?.toLowerCase()}>{EPOCH_STATUS[currentEpochData?.status]}</Status>
           </ProgressCircle>
         </Box>
       )


### PR DESCRIPTION
## Description

Not navigate to epoch detail when click epoch number inprogess

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/79d3421a-fa56-4884-8244-00ac13b6978e)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/50ae749a-8dd3-4ed7-8b97-af8c937d4e87)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

same pc

##### _After_

same pc

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ