### PR TITLE
fix: contract display full when hover still dis play tooltip

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Contracts/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Contracts/index.tsx
@@ -66,9 +66,13 @@ const Contracts: React.FC<ContractsProps> = ({ data }) => {
               <Box display={"flex"} alignItems="center" padding={"15px 0 0"} key={ct.contract}>
                 <Box mx={"auto"} display="flex" alignItems={"center"}>
                   <Link to={redirectTo(ct.contract)}>
-                    <CustomTooltip title={ct.contract}>
-                      <Title>{isLargeTablet ? getShortWallet(ct.contract) : ct.contract}</Title>
-                    </CustomTooltip>
+                    {isLargeTablet ? (
+                      <CustomTooltip title={ct.contract}>
+                        <Title>{getShortWallet(ct.contract)}</Title>
+                      </CustomTooltip>
+                    ) : (
+                      <Title>{ct.contract}</Title>
+                    )}
                   </Link>
                 </Box>
                 <CopyButton text={ct.contract} />


### PR DESCRIPTION
## Description

Contract display full when hover still dis play tooltip

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/f4a33a83-c92c-45cb-96aa-6e7a4ecd6996)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a9d6658a-9bb2-4e64-8bdf-0d9d29523653)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/e2bf5eb7-bba1-455f-813f-d398b530c9e2)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a336e62f-9308-46f2-bf55-8d1b490e3a8b)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ