### PR TITLE
fix: MET-1342-finding-5-close-modal-when-user-click-outside

### DIFF
--- a/src/components/commons/StyledModal/index.tsx
+++ b/src/components/commons/StyledModal/index.tsx
@@ -30,7 +30,7 @@ const StyledModal: React.FC<IProps> = ({
   const { isMobile } = useScreen();
 
   return (
-    <Modal open={open}>
+    <Modal open={open} onClose={handleCloseModal}>
       <ModalContainer
         width={width}
         height={height}
@@ -39,7 +39,7 @@ const StyledModal: React.FC<IProps> = ({
         viewwidth={isMobile ? 92 : 70}
         sx={modalStyle}
       >
-        <CloseButton saving={0} onClick={() => handleCloseModal()} data-testid="close-modal-button">
+        <CloseButton saving={0} onClick={handleCloseModal} data-testid="close-modal-button">
           <IoMdClose />
         </CloseButton>
         {title && (


### PR DESCRIPTION
## Description

Close-modal-when-user-click-outside

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1342](https://cardanofoundation.atlassian.net/browse/MET-1342)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7b128927-2c6d-486f-8b52-ec842f30da35)


##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/81b27313-8e48-466e-9c2b-9c84e428e324)
#### Safari
##### _Before_

same chrome
##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6a906a2b-1924-42ee-9d23-98820a353d57)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/73a63346-596f-464b-8f2b-77b3dbe6a9f5)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1342]: https://cardanofoundation.atlassian.net/browse/MET-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ