### PR TITLE
fix:MET-1342-finding-4-close-box-more-infor-when-user-click-outside-box

### DIFF
--- a/src/components/commons/PopperStyled/index.tsx
+++ b/src/components/commons/PopperStyled/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Box, Popper, styled } from "@mui/material";
 
 import { CloseLineIcon } from "src/commons/resources";
@@ -36,6 +36,20 @@ type Props = {
 const PopperStyled = (props: Props) => {
   const [anchorEl, setAnchorEl] = useState<(EventTarget & HTMLElement) | null>(null);
   const { render, content, showCloseButton = true } = props;
+  const refElement = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (refElement.current && !(event.target instanceof Node && refElement.current.contains(event.target))) {
+      setAnchorEl(null);
+    }
+  };
 
   const handleClick = (element: HTMLElement) => {
     setAnchorEl(element);
@@ -50,7 +64,7 @@ const PopperStyled = (props: Props) => {
   return (
     <>
       {render({ handleClick: anchorEl ? handleClose : handleClick })}
-      <StyledPopper open={open} anchorEl={anchorEl} placement={"top-start"}>
+      <StyledPopper open={open} anchorEl={anchorEl} placement={"top-start"} ref={refElement}>
         {showCloseButton && (
           <Box
             onClick={handleClose}


### PR DESCRIPTION
## Description

Close box more info when user click outside box

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1342](https://cardanofoundation.atlassian.net/browse/MET-1342)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/612734be-9ae6-485a-b92b-f79a752cddda)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/31398cf5-5755-4c43-bceb-63a62c65da16)

#### Safari
same chome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/d3533ce2-14b8-45a5-a5f7-50bceb26bc72)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9c0e7236-bc76-4760-8db9-6e0aac27c789)

[MET-1342]: https://cardanofoundation.atlassian.net/browse/MET-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ