### PR TITLE
bugfix:MET-615 Epoch detail and Block detail are missing opacity.

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -15,7 +15,7 @@ import { CONFIRMATION_STATUS, MAX_SLOT_EPOCH } from "src/commons/utils/constants
 import ADAicon from "src/components/commons/ADAIcon";
 import DetailHeader from "src/components/commons/DetailHeader";
 
-import { ConfirmStatus, TitleCard, WrapConfirmation } from "./styles";
+import { ConfirmStatus, Subtext, TitleCard, WrapConfirmation } from "./styles";
 
 interface BlockOverviewProps {
   data: BlockDetail | null;
@@ -116,9 +116,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
       value: (
         <>
           {data?.epochSlotNo || 0}
-          <Box component={"span"} fontWeight="400">
-            /{MAX_SLOT_EPOCH}
-          </Box>
+          <Subtext>/{MAX_SLOT_EPOCH}</Subtext>
         </>
       )
     }

--- a/src/components/BlockDetail/BlockOverview/styles.ts
+++ b/src/components/BlockDetail/BlockOverview/styles.ts
@@ -60,3 +60,8 @@ export const WrapConfirmation = styled(Box)(({ theme }) => ({
     paddingTop: "5px"
   }
 }));
+
+export const Subtext = styled("span")`
+  opacity: 0.5;
+  font-weight: 400;
+`;

--- a/src/components/EpochDetail/EpochOverview/index.tsx
+++ b/src/components/EpochDetail/EpochOverview/index.tsx
@@ -3,14 +3,21 @@ import { Box } from "@mui/material";
 import { useSelector } from "react-redux";
 import moment from "moment";
 
-import { timeIconUrl, outputIconUrl, cubeIconUrl, slotIconUrl, exchageIconUrl, RewardIcon } from "src/commons/resources";
+import {
+  timeIconUrl,
+  outputIconUrl,
+  cubeIconUrl,
+  slotIconUrl,
+  exchageIconUrl,
+  RewardIcon
+} from "src/commons/resources";
 import { MAX_SLOT_EPOCH } from "src/commons/utils/constants";
 import DetailHeader from "src/components/commons/DetailHeader";
 import { TitleCard } from "src/components/BlockDetail/BlockOverview/styles";
 import { formatADAFull, formatDateTimeLocal } from "src/commons/utils/helper";
 import ADAicon from "src/components/commons/ADAIcon";
 
-import { Output } from "./styles";
+import { Output, Subtext } from "./styles";
 
 interface EpochOverviewProps {
   data: IDataEpoch | null;
@@ -72,10 +79,8 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       ),
       value: (
         <>
-          {moment(formatDateTimeLocal(data?.endTime || "")).diff(moment()) > 0 ? slot : MAX_SLOT_EPOCH}/
-          <Box component={"span"} fontWeight="400">
-            {MAX_SLOT_EPOCH}
-          </Box>
+          {moment(formatDateTimeLocal(data?.endTime || "")).diff(moment()) > 0 ? slot : MAX_SLOT_EPOCH}
+          <Subtext>/{MAX_SLOT_EPOCH}</Subtext>
         </>
       )
     },
@@ -86,8 +91,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
           <TitleCard mr={1}> Transaction Count</TitleCard>
         </Box>
       ),
-      value:
-        data?.txCount
+      value: data?.txCount
     },
     {
       icon: RewardIcon,
@@ -98,15 +102,15 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       ),
       value: (
         <>
-        {data?.rewardsDistributed ? (
-          <Output>
-            {formatADAFull(data?.rewardsDistributed)}
-            <ADAicon />
-          </Output>
-        ) : (
-          "Not available"
-        )}
-      </>
+          {data?.rewardsDistributed ? (
+            <Output>
+              {formatADAFull(data?.rewardsDistributed)}
+              <ADAicon />
+            </Output>
+          ) : (
+            "Not available"
+          )}
+        </>
       )
     }
   ];

--- a/src/components/EpochDetail/EpochOverview/styles.ts
+++ b/src/components/EpochDetail/EpochOverview/styles.ts
@@ -46,8 +46,13 @@ export const ProgressPercent = styled("h4")`
   color: ${(props) => props.theme.palette.primary.main};
 `;
 
-export const Output = styled('span')`
+export const Output = styled("span")`
   display: inline-flex;
   align-items: center;
   gap: 10px;
+`;
+
+export const Subtext = styled("span")`
+  opacity: 0.5;
+  font-weight: 400;
 `;


### PR DESCRIPTION
## Description

MET-615 Epoch detail and Block detail are missing opacity

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
<img width="954" alt="img1" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/5671c910-50fa-49bc-8f80-b5ac47ac1282">
<img width="955" alt="img2" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/a8853fbb-87d4-470a-8f1a-ec84fa1318d7">


##### _After_
<img width="1512" alt="Screenshot 2023-06-24 at 15 31 39" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/f2a05b2e-1d18-45ab-bd61-13dca6f4ba84">
![Screenshot 2023-06-24 at 15 31 39 (2)](https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/0e90bcb0-e43f-4fd9-a003-ee53c1462c3a)
<img width="1512" alt="Screenshot 2023-06-24 at 15 32 05" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/bdc2b9cc-5359-41ed-b8aa-54ed8d0de821">
![Screenshot 2023-06-24 at 15 32 05 (2)](https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/04087663-5996-4e74-95b9-1b35a2cc0320)




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ