### PR TITLE
bugfix:MET-615 The pop-up is too long, causing the top and bottom par…

### DIFF
--- a/src/components/TokenAutocomplete/index.tsx
+++ b/src/components/TokenAutocomplete/index.tsx
@@ -8,9 +8,9 @@ import { EmptyIcon, HeaderSearchIcon } from "src/commons/resources";
 import { details } from "src/commons/routers";
 import { API } from "src/commons/utils/api";
 import { formatNumberDivByDecimals, getShortWallet, numberWithCommas } from "src/commons/utils/helper";
+import { useScreen } from "src/commons/hooks/useScreen";
 
 import CustomTooltip from "../commons/CustomTooltip";
-import StyledModal from "../commons/StyledModal";
 import Table, { Column } from "../commons/Table";
 import { WrappModalScrollBar } from "../commons/Table/styles";
 import {
@@ -24,6 +24,7 @@ import {
   StyledTextField,
   SubmitButton
 } from "./styles";
+import CustomModal from "../commons/CustomModal";
 
 const TokenAutocomplete = ({ address }: { address: string }) => {
   const [openModalToken, setOpenModalToken] = useState(false);
@@ -154,6 +155,7 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
     page,
     size
   });
+  const { isTablet } = useScreen();
 
   const columns: Column<WalletAddress["tokens"][number]>[] = [
     {
@@ -199,7 +201,7 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
   };
 
   return (
-    <StyledModal title="Token List" open={open} handleCloseModal={handleClose} width={"min(80vw, 600px)"}>
+    <CustomModal title="Token List" open={open} onClose={handleClose} width={"min(80vw, 600px)"}>
       <>
         <SearchContainer mt={2} mb={1}>
           <StyledInput
@@ -223,7 +225,7 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
             data={data || []}
             columns={columns}
             total={{ title: "Total", count: fetchData.total }}
-            maxHeight={"55vh"}
+            maxHeight={isTablet ? "50vh" : "55vh"}
             pagination={{
               page,
               size,
@@ -233,6 +235,6 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
           />
         </WrappModalScrollBar>
       </>
-    </StyledModal>
+    </CustomModal>
   );
 };


### PR DESCRIPTION
## Description
The pop-up is too long, causing the top and bottom parts to be cut off.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![Screenshot_20230622_155041_Chrome](https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/d4616631-0ca0-4d0b-81d7-d131a2d8b27d)

##### _After_
![Screenshot_20230624_154229_Chrome](https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/37172082-c4b1-4d42-bcc0-8fff286fefaf)



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ