### PR TITLE
fix: MET-1342-change-places-icon-timeline-view-and-tabular-view

### DIFF
--- a/src/pages/DelegatorLifecycle/index.tsx
+++ b/src/pages/DelegatorLifecycle/index.tsx
@@ -111,11 +111,11 @@ const DelegatorLifecycle = () => {
             <BoxSwitchContainer sidebar={+sidebar}>
               <LabelSwitch>Switch to {validMode === "timeline" ? "tabular" : "timeline"} view</LabelSwitch>
               <SwitchGroup>
-                <ButtonSwitch active={+(validMode === "tabular")} onClick={() => changeMode("tabular")}>
-                  <ChartMode fill={validMode === "tabular" ? theme.palette.common.white : theme.palette.grey[500]} />
-                </ButtonSwitch>
                 <ButtonSwitch active={+(validMode === "timeline")} onClick={() => changeMode("timeline")}>
                   <TableMode fill={validMode === "timeline" ? theme.palette.common.white : theme.palette.grey[500]} />
+                </ButtonSwitch>
+                <ButtonSwitch active={+(validMode === "tabular")} onClick={() => changeMode("tabular")}>
+                  <ChartMode fill={validMode === "tabular" ? theme.palette.common.white : theme.palette.grey[500]} />
                 </ButtonSwitch>
               </SwitchGroup>
             </BoxSwitchContainer>

--- a/src/pages/SPOLifecycle/index.tsx
+++ b/src/pages/SPOLifecycle/index.tsx
@@ -113,11 +113,11 @@ const SPOLifecycle = () => {
             <BoxSwitchContainer sidebar={+sidebar}>
               <LabelSwitch>Switch to {validMode === "timeline" ? "tabular" : "timeline"} view</LabelSwitch>
               <SwitchGroup>
-                <ButtonSwitch active={+(validMode === "tabular")} onClick={() => changeMode("tabular")}>
-                  <ChartMode fill={validMode === "tabular" ? theme.palette.common.white : theme.palette.grey[500]} />
-                </ButtonSwitch>
                 <ButtonSwitch active={+(validMode === "timeline")} onClick={() => changeMode("timeline")}>
                   <TableMode fill={validMode === "timeline" ? theme.palette.common.white : theme.palette.grey[500]} />
+                </ButtonSwitch>
+                <ButtonSwitch active={+(validMode === "tabular")} onClick={() => changeMode("tabular")}>
+                  <ChartMode fill={validMode === "tabular" ? theme.palette.common.white : theme.palette.grey[500]} />
                 </ButtonSwitch>
               </SwitchGroup>
             </BoxSwitchContainer>


### PR DESCRIPTION
## Description

Change places icon timeline view and tabular view

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1342](https://cardanofoundation.atlassian.net/browse/MET-1342)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8b8a0fc5-c75e-465c-b610-d42f597a11f8)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9a809a5b-fb78-4cae-8ba0-ad2208c0ed5d)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8b8a0fc5-c75e-465c-b610-d42f597a11f8)
##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9a809a5b-fb78-4cae-8ba0-ad2208c0ed5d)


[MET-1342]: https://cardanofoundation.atlassian.net/browse/MET-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ