### PR TITLE
fix: MET-1344 finding 1 text shifted to the left in small screen

### DIFF
--- a/src/pages/DelegatorLifecycle/styles.ts
+++ b/src/pages/DelegatorLifecycle/styles.ts
@@ -73,7 +73,7 @@ export const BoxItemStyled = styled(Box)<{ sidebar?: number }>(({ theme, sidebar
 export const BoxSwitchContainer = styled(Box)<{ sidebar?: number }>(({ theme, sidebar }) => ({
   display: "flex",
   alignItems: "center",
-  justifyContent: "space-between",
+  justifyContent: "flex-end",
   gap: 15,
   [theme.breakpoints.down("lg")]: {
     width: sidebar ? "100%" : "auto"

--- a/src/pages/SPOLifecycle/styles.ts
+++ b/src/pages/SPOLifecycle/styles.ts
@@ -73,7 +73,7 @@ export const BoxItemStyled = styled(Box)<{ sidebar?: number }>(({ theme, sidebar
 export const BoxSwitchContainer = styled(Box)<{ sidebar?: number }>(({ theme, sidebar }) => ({
   display: "flex",
   alignItems: "center",
-  justifyContent: "space-between",
+  justifyContent: "flex-end",
   gap: 15,
   [theme.breakpoints.down("lg")]: {
     width: sidebar ? "100%" : "auto"


### PR DESCRIPTION
## Description

Text shifted to the left in small screen

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1344](https://cardanofoundation.atlassian.net/browse/MET-1344)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/b04fd93a-423d-47c9-8707-50530a5bcf90)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/2f917e99-8879-452d-9043-cba1d592e6ae)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/be724c96-d6a1-4afc-806a-8babeb6329b3)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/97f5be5d-ce51-4d47-9ff5-8a63f63b38d4)

[MET-1344]: https://cardanofoundation.atlassian.net/browse/MET-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ