### PR TITLE
fix: MET-1342-finding-3-expand-the-click-area-for-tabs

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/index.tsx
@@ -182,6 +182,12 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
     return `${palette.grey[200]} !important`;
   };
 
+  const handleChangeTab = (step: StepperProps, idx: number) => {
+    if (tabsRenderConfig[step.keyCheckShow] && currentStep !== idx) {
+      setCurrentStep(idx);
+      history.replace(details.staking(stakeId, "timeline", step.key));
+    }
+  };
   return (
     <Box>
       <Box display={"flex"} justifyContent={"space-between"} sx={{ overflowX: "auto" }}>
@@ -193,17 +199,12 @@ const DelegatorLifecycle = ({ currentStep, setCurrentStep, tabsRenderConfig }: P
               component={tabsRenderConfig[step.keyCheckShow] ? "span" : CustomTooltip}
               active={+(currentStep === idx)}
               title={tabsRenderConfig[step.keyCheckShow] ? undefined : "There is no record at this time"}
+              onClick={() => handleChangeTab(step, idx)}
             >
               <Box>
                 <StepButton
                   component={IconButton}
                   active={+(currentStep === idx)}
-                  onClick={() => {
-                    if (tabsRenderConfig[step.keyCheckShow] && currentStep !== idx) {
-                      setCurrentStep(idx);
-                      history.replace(details.staking(stakeId, "timeline", step.key));
-                    }
-                  }}
                   bgcolor={renderBackground(currentStep === idx, tabsRenderConfig[step.keyCheckShow])}
                   color={({ palette }) =>
                     tabsRenderConfig[step.keyCheckShow] ? palette.common.white : palette.grey[300]

--- a/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/styles.ts
@@ -9,7 +9,8 @@ export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
   },
   [theme.breakpoints.down("sm")]: {
     padding: "16px 30px"
-  }
+  },
+  cursor: "pointer"
 }));
 
 export const StepButton = styled(Box)<{ active: number }>(({ theme, active }) => ({

--- a/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
+++ b/src/components/StakingLifeCycle/SPOLifecycle/index.tsx
@@ -139,6 +139,13 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
     return `${palette.grey[200]} !important`;
   };
 
+  const handleChangeTab = (step: StepperProps, idx: number) => {
+    if (renderTabsSPO[step.keyCheckShow] && currentStep !== idx) {
+      history.replace(details.spo(poolId, "timeline", step.key));
+      setCurrentStep(idx);
+    }
+  };
+
   return (
     <StyledComponent>
       <Box display={"flex"} justifyContent={"space-between"}>
@@ -149,17 +156,12 @@ const SPOLifecycle = ({ currentStep, setCurrentStep, renderTabsSPO }: Props) => 
             active={+(currentStep === idx)}
             component={renderTabsSPO[step.keyCheckShow] ? "span" : CustomTooltip}
             title={renderTabsSPO[step.keyCheckShow] ? undefined : "There is no record at this time"}
+            onClick={() => handleChangeTab(step, idx)}
           >
             <Box>
               <StepButton
                 component={IconButton}
                 active={+(currentStep === idx)}
-                onClick={() => {
-                  if (renderTabsSPO[step.keyCheckShow] && currentStep !== idx) {
-                    history.replace(details.spo(poolId, "timeline", step.key));
-                    setCurrentStep(idx);
-                  }
-                }}
                 bgcolor={renderBackground(currentStep === idx, renderTabsSPO[step.keyCheckShow])}
                 color={({ palette }) => (renderTabsSPO[step.keyCheckShow] ? palette.common.white : palette.grey[300])}
               >

--- a/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
+++ b/src/components/StakingLifeCycle/SPOLifecycle/styles.ts
@@ -7,7 +7,8 @@ export const Step = styled(Box)<{ active: number }>(({ theme, active }) => ({
   borderBottom: `3px solid ${active ? theme.palette.green[600] : theme.palette.grey[200]}`,
   [theme.breakpoints.down("sm")]: {
     padding: "16px 30px"
-  }
+  },
+  cursor: "pointer"
 }));
 
 export const StepButton = styled(Box)<{ active: number }>(({ theme, active }) => ({


### PR DESCRIPTION
## Description

Expand the click area for tabs

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1342](https://cardanofoundation.atlassian.net/browse/MET-1342)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5b07ac7d-0464-462e-924f-054dcdff86d3)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7394bc88-27de-4f24-af8b-a9a77cb45a87)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5b07ac7d-0464-462e-924f-054dcdff86d3)
##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7394bc88-27de-4f24-af8b-a9a77cb45a87)


[MET-1342]: https://cardanofoundation.atlassian.net/browse/MET-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ