### PR TITLE
fix: wrong syntax word

### DIFF
--- a/src/components/Home/Trending/TransactionChart/TransactionChart.test.tsx
+++ b/src/components/Home/Trending/TransactionChart/TransactionChart.test.tsx
@@ -1,12 +1,12 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import { useSelector } from "react-redux";
+import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 
 import { render } from "src/test-utils";
 import useFetch from "src/commons/hooks/useFetch";
-import { Router } from "react-router-dom";
 import { numberWithCommas } from "src/commons/utils/helper";
 
 import TransactionChart, { TransactionChartIF } from ".";
@@ -57,7 +57,6 @@ const mockItemMonth: TransactionChartIF = {
 };
 
 const getData = (url: string) => {
-  console.log(url.split("/")[2]);
   switch (url.split("/")[2]) {
     case "ONE_DAY":
       return mockItemDay;
@@ -108,7 +107,7 @@ describe("TransactionChart", () => {
 
     await userEvent.click(twoWeek);
     await waitFor(async () => {
-      expect(screen.getByText("Transactions in two week")).toBeInTheDocument();
+      expect(screen.getByText("Transactions in two weeks")).toBeInTheDocument();
       expect(screen.getByTestId("trx")).toHaveTextContent(numberWithCommas(mockItem2Week.simpleTransactions));
       expect(screen.getByTestId("simple")).toHaveTextContent(numberWithCommas(mockItem2Week.smartContract));
       expect(screen.getByTestId("complex")).toHaveTextContent(numberWithCommas(mockItem2Week.metadata));

--- a/src/components/Home/Trending/TransactionChart/index.tsx
+++ b/src/components/Home/Trending/TransactionChart/index.tsx
@@ -42,15 +42,15 @@ const TransactionChart: React.FC = () => {
     },
     ONE_WEEK: {
       label: "1w",
-      displayName: "in week"
+      displayName: "in a week"
     },
     TWO_WEEK: {
       label: "2w",
-      displayName: "in two week"
+      displayName: "in two weeks"
     },
     ONE_MONTH: {
       label: "1m",
-      displayName: "in month"
+      displayName: "in a month"
     }
   };
 


### PR DESCRIPTION
## Description

fix: wrong syntax word
## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1259](https://cardanofoundation.atlassian.net/browse/MET-1259)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
Before:
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/afe1d5c0-5583-4d3d-8a4e-862398127e69)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/47389f5b-7948-4153-95c3-cd8530146dcf)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/182b15e8-3010-4622-91ff-bd37020a17cc)
After:
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/47e2b03f-c8d2-42e2-b07f-b5dc89e7d8a2)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/df7cc9c0-6ed6-4ff7-bce0-b24c13327cf0)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/d29d9b0c-bc19-413e-8c01-d8b3a17af416)


[MET-1259]: https://cardanofoundation.atlassian.net/browse/MET-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ