### PR TITLE
fix: MET-1311 update list search token

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Summary/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Summary/index.tsx
@@ -1,18 +1,19 @@
 import { Box, useTheme } from "@mui/material";
 import React from "react";
 import { Link } from "react-router-dom";
+import { RiArrowRightSLine } from "react-icons/ri";
 
 import { TransferIcon } from "src/commons/resources";
 
 import receiveImg from "../../../../commons/resources/images/receiveImg.svg";
 import sendImg from "../../../../commons/resources/images/sendImg.svg";
 import { details } from "../../../../commons/routers";
-import { formatADAFull, getShortWallet } from "../../../../commons/utils/helper";
+import { formatADAFull, getShortWallet, numberWithCommas } from "../../../../commons/utils/helper";
 import ADAicon from "../../../commons/ADAIcon";
 import CopyButton from "../../../commons/CopyButton";
 import CustomTooltip from "../../../commons/CustomTooltip";
 import DropdownTokens from "../../../commons/DropdownTokens";
-import { Icon } from "./styles";
+import { Icon, TokenButton } from "./styles";
 import { useScreen } from "../../../../commons/hooks/useScreen";
 
 const SummaryItems = ({
@@ -28,6 +29,48 @@ const SummaryItems = ({
 
   const theme = useTheme();
   const { isMobile } = useScreen();
+
+  const renderToken = (token: Token) => {
+    const isNegative = token.assetQuantity <= 0;
+    const tokenName = token.assetName || token.assetId;
+    const shortTokenName = getShortWallet(tokenName);
+    const isTokenNameLong = tokenName.length > 20;
+
+    return (
+      <TokenButton>
+        <Box
+          component={Link}
+          to={details.token(token.assetId)}
+          display={"flex"}
+          alignItems={"center"}
+          justifyContent={"space-between"}
+          pl={2}
+          width={"100%"}
+          height={38}
+        >
+          <Box mr={2}>
+            {isTokenNameLong ? (
+              <CustomTooltip title={tokenName} placement="top">
+                <Box>{shortTokenName}</Box>
+              </CustomTooltip>
+            ) : (
+              tokenName
+            )}
+          </Box>
+          <Box display={"flex"} alignItems={"center"}>
+            <Box fontWeight={"bold"} fontSize={"14px"}>
+              {isNegative ? "" : "+"}
+              {`${numberWithCommas(token.assetQuantity) || ""}`}
+            </Box>
+            <Box pr={1}>
+              <RiArrowRightSLine />
+            </Box>
+          </Box>
+        </Box>
+      </TokenButton>
+    );
+  };
+
   return (
     <Box
       display={"flex"}
@@ -107,12 +150,15 @@ const SummaryItems = ({
           </Box>
         </Box>
       </Box>
-      {item.tokens && item.tokens.length > 0 ? (
+      {item.tokens && item.tokens.length === 1 && (
+        <Box display={"flex"} alignItems={"center"} ml={isMobile ? "50px" : 0}>
+          {renderToken(item.tokens[0])}
+        </Box>
+      )}
+      {item.tokens && item.tokens.length > 1 && (
         <Box display={"flex"} alignItems={"center"} ml={isMobile ? "50px" : 0}>
           <DropdownTokens tokens={item.tokens} type={type} hideInputLabel />
         </Box>
-      ) : (
-        <Box />
       )}
     </Box>
   );

--- a/src/components/TransactionDetail/TransactionMetadata/Summary/styles.ts
+++ b/src/components/TransactionDetail/TransactionMetadata/Summary/styles.ts
@@ -1,4 +1,4 @@
-import { MenuItem, Select, alpha, styled } from "@mui/material";
+import { Box, MenuItem, Select, alpha, styled } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const Img = styled("img")(() => ({
@@ -98,4 +98,13 @@ export const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
   "&.Mui-selected": {
     backgroundColor: theme.palette.background.paper
   }
+}));
+
+export const TokenButton = styled(Box)(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  minWidth: 250,
+  height: 38,
+  borderRadius: theme.spacing(1),
+  border: `1px solid ${alpha(theme.palette.grey[300], 0.5)}`
 }));

--- a/src/components/commons/DropdownTokens/index.tsx
+++ b/src/components/commons/DropdownTokens/index.tsx
@@ -38,11 +38,19 @@ const DropdownTokens: React.FC<IDropdownTokens> = ({ tokens, hideInputLabel, hid
       IconComponent={() =>
         openDropdown ? (
           <>
-            <BiChevronUp size={30} style={{ paddingRight: 10, fontSize: "20px", cursor: "pointer" }} onClick={() => setOpenDropdown(false)} />
+            <BiChevronUp
+              size={30}
+              style={{ paddingRight: 10, fontSize: "20px", cursor: "pointer" }}
+              onClick={() => setOpenDropdown(false)}
+            />
           </>
         ) : (
           <>
-            <BiChevronDown size={30} style={{ paddingRight: 10, fontSize: "20px", cursor: "pointer" }} onClick={() => setOpenDropdown(true)} />
+            <BiChevronDown
+              size={30}
+              style={{ paddingRight: 10, fontSize: "20px", cursor: "pointer" }}
+              onClick={() => setOpenDropdown(true)}
+            />
           </>
         )
       }


### PR DESCRIPTION
## Description

When there is only one token, display the token information and clicking on it will gradually go to the detail page. when there is more than 1 token show the same dropdown list

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-1311)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/e6908c36-191d-4d8c-bf2d-9e050742486d)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/1274e5b3-affc-47cb-9086-d14b7abfd719)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)