### PR TITLE
fix: MET-615-Not-show-shortened-Private-notes-with-length-more-than-6…

### DIFF
--- a/src/pages/PrivateNotes/styles.ts
+++ b/src/pages/PrivateNotes/styles.ts
@@ -77,7 +77,10 @@ export const StyledTable = styled(Table)(({ theme }) => ({
     height: "60px"
   },
   "& tbody tr td": {
-    padding: "0 20px"
+    padding: "0 20px",
+    "&:first-child": {
+      paddingRight: 0
+    }
   },
   [theme.breakpoints.down("sm")]: {
     "& > div": {
@@ -117,6 +120,8 @@ export const SmallText = styled("small")`
   white-space: nowrap;
   color: ${(props) => props.theme.palette.grey[500]};
   margin-top: 4px;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 export const CancelButton = styled(Button)(({ theme }) => ({
   textTransform: "capitalize",


### PR DESCRIPTION
## Description
Not show shortened private notes with length more than 60 characters

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/abdd5260-a9aa-4863-8490-9aad3f31538f)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/d55a877b-5c6c-4ef3-87bd-be149d761b12)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3c438d9f-ac10-4942-af65-486053ba261e)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ba87be85-064d-4188-b62c-09eaeea991e4)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ