### PR TITLE
fix: MET-615-ADA-transfer-report-detail-missing-tooltip

### DIFF
--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/WalletActivityTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/WalletActivityTab.tsx
@@ -11,6 +11,7 @@ import { StyledLink } from "src/components/share/styled";
 import { details } from "src/commons/routers";
 import useFetchList from "src/commons/hooks/useFetchList";
 import { API } from "src/commons/utils/api";
+import CustomTooltip from "src/components/commons/CustomTooltip";
 
 const WalletActitityTab = () => {
   const [sort, setSort] = useState<string>("");
@@ -48,7 +49,13 @@ const WalletActitityTab = () => {
       title: "Transaction Hash",
       key: "transactionHash",
       minWidth: "100px",
-      render: (r) => <StyledLink to={details.transaction(r.txHash || "")}>{getShortHash(r.txHash)}</StyledLink>
+      render: (r) => (
+        <StyledLink to={details.transaction(r.txHash || "")}>
+          <CustomTooltip title={r.txHash}>
+            <Box component={"span"}>{getShortHash(r.txHash)}</Box>
+          </CustomTooltip>
+        </StyledLink>
+      )
     },
     {
       title: "Status",


### PR DESCRIPTION
## Description

ADA transfer report detail missing tooltip

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/0eb54f38-67c5-493e-9912-d8044ae2f54b)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/4a91f7b0-2746-4524-8f5b-3d8b9b402fd7)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8a277c6c-0a91-4739-9c59-0880d170a214)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/0ee3c5f4-13e3-454e-8908-bf60c415951d)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ