### PR TITLE
fix: MET-615 position of sidebar menu is invalid when rotate Ipad

### DIFF
--- a/src/commons/hooks/useScreen.test.ts
+++ b/src/commons/hooks/useScreen.test.ts
@@ -1,7 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { useTheme } from "@mui/material";
 import { useSelector } from "react-redux";
-import { useWindowSize } from "react-use";
 
 import { useScreen } from "./useScreen";
 
@@ -13,10 +12,6 @@ jest.mock("react-redux", () => ({
   useSelector: jest.fn()
 }));
 
-jest.mock("react-use", () => ({
-  useWindowSize: jest.fn()
-}));
-
 describe("useScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -25,8 +20,8 @@ describe("useScreen", () => {
   it("should return correct screen properties", () => {
     const theme = { breakpoints: { values: { sm: 600, md: 900, lg: 1200, xl: 1536 } } };
     const width = 700;
+    global.innerWidth = width;
     (useTheme as jest.Mock).mockReturnValue(theme);
-    (useWindowSize as jest.Mock).mockReturnValue({ width });
     (useSelector as jest.Mock).mockReturnValue({ sidebar: false });
 
     const { result } = renderHook(() => useScreen());

--- a/src/commons/hooks/useScreen.ts
+++ b/src/commons/hooks/useScreen.ts
@@ -1,19 +1,34 @@
+import { useEffect, useState } from "react";
 import { useTheme } from "@mui/material";
 import { useSelector } from "react-redux";
-import { useWindowSize } from "react-use";
 
 export const SAMSUNG_FOLD_SMALL_WIDTH = 355;
 export const IPAD_PRO = 1270;
+
 export const useScreen = () => {
   const { sidebar } = useSelector(({ user }: RootState) => user);
   const theme = useTheme();
-  const { width } = useWindowSize(0);
+  const [width, setWidth] = useState(window.innerWidth);
 
-  const isMobile = width < theme.breakpoints.values.sm;
-  const isTablet = width < theme.breakpoints.values.md;
-  const isLaptop = width < theme.breakpoints.values.lg;
-  const isSmallScreen = (width < theme.breakpoints.values.lg && sidebar) || isTablet;
+  useEffect(() => {
+    const responsive = () => setWidth(window.innerWidth);
+
+    window.addEventListener("resize", responsive);
+    window.addEventListener("orientationchange", responsive);
+
+    return () => {
+      window.removeEventListener("resize", responsive);
+      window.removeEventListener("orientationchange", responsive);
+    };
+  }, []);
+
+  const { sm, md, lg } = theme.breakpoints.values;
+  const isMobile = width < sm;
+  const isTablet = width < md;
+  const isLaptop = width < lg;
+  const isSmallScreen = (width < lg && sidebar) || isTablet;
   const isGalaxyFoldSmall = width <= SAMSUNG_FOLD_SMALL_WIDTH;
   const isLargeTablet = width <= IPAD_PRO;
+
   return { isMobile, isTablet, isLaptop, isGalaxyFoldSmall, isLargeTablet, isSmallScreen, width };
 };

--- a/src/components/commons/Layout/styles.ts
+++ b/src/components/commons/Layout/styles.ts
@@ -147,7 +147,7 @@ export const Main = styled(Box)<{ open: number }>(({ theme, open }) => ({
   overflowX: "hidden",
   overflowY: "auto",
   width: `calc(100vw - ${drawerCollaspWidth}px)`,
-  height: "calc(100vh - 61px)",
+  minHeight: "calc(100vh - 61px)",
   transition: theme.transitions.create("width", {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen


### PR DESCRIPTION
## Description

Responsive not working in Ipad when rotating device.
Position of Sidebar Menu is invalid after Ipad rotate because useWindowSize hook returns wrong width. 

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No jira ticket

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

No change

#### Safari

No change

#### Responsive

IPad Pro M1: Position Sidebar Menu is right instead left when rotating device (width > 900px).

| Before | After |
| -------- | -------- |
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/ac3f993d-84c1-4cb1-b27a-204773f9a93a) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/90748473-59b7-4d1e-82cd-1a58ed0ad47f) |