### PR TITLE
fix: page size select wrong after unfocused page input

### DIFF
--- a/src/components/Home/TopDelegationPools/TopDelegationPools.test.tsx
+++ b/src/components/Home/TopDelegationPools/TopDelegationPools.test.tsx
@@ -68,9 +68,8 @@ describe("TopDelegationPools", () => {
     expect(screen.getByText(mockItem.poolName)).toBeInTheDocument();
     expect(screen.getByText(formatADAFull(mockItem.poolSize))).toBeInTheDocument();
     expect(screen.getByText("+3,49 %")).toBeInTheDocument();
-    expect(
-      screen.getByText(`${formatPercent(mockItem.feePercent)} (${formatADAFull(mockItem.feeAmount)} A)`)
-    ).toBeInTheDocument();
+    expect(screen.getByText(formatPercent(mockItem.feePercent))).toBeInTheDocument();
+    expect(screen.getByText(`${formatADAFull(mockItem.feeAmount)} A`)).toBeInTheDocument();
     expect(screen.getByText(formatADAFull(mockItem.pledge))).toBeInTheDocument();
     expect(screen.getByText(formatPercent(mockItem.saturation / 100))).toBeInTheDocument();
   });

--- a/src/components/commons/Table/index.tsx
+++ b/src/components/commons/Table/index.tsx
@@ -271,7 +271,6 @@ export const FooterTable: React.FC<FooterTableProps> = ({ total, pagination, loa
   };
 
   useEffect(() => {
-    console.log(trigger);
     trigger && setOpen(false);
   }, [trigger, setOpen]);
 

--- a/src/components/commons/Table/index.tsx
+++ b/src/components/commons/Table/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, PaginationRenderItemParams, IconButton, MenuItem, styled, CircularProgress, alpha } from "@mui/material";
 import { useUpdateEffect } from "react-use";
 import { useParams } from "react-router-dom";
+import { useScrollTrigger } from "@mui/material";
 
 import { handleClicktWithoutAnchor, numberWithCommas } from "src/commons/utils/helper";
 import {
@@ -255,6 +256,8 @@ export const FooterTable: React.FC<FooterTableProps> = ({ total, pagination, loa
   const defaultPage = pagination?.page && (pagination?.page === 0 ? 1 : pagination?.page + 1);
   const [page, setPage] = useState(defaultPage || 1);
   const [size, setSize] = useState(pagination?.size || 50);
+  const [open, setOpen] = useState(false);
+  const trigger = useScrollTrigger();
   const { poolType } = useParams<{ poolType: "registration" | "de-registration" }>();
 
   useUpdateEffect(() => {
@@ -267,12 +270,20 @@ export const FooterTable: React.FC<FooterTableProps> = ({ total, pagination, loa
     clearSelection?.();
   };
 
+  useEffect(() => {
+    console.log(trigger);
+    trigger && setOpen(false);
+  }, [trigger, setOpen]);
+
   return (
     <TFooter>
       <Box display={"flex"} alignItems="center" margin="15px 0px">
         {pagination?.total && pagination.total > 10 ? (
           <Box display="flex" alignItems="center">
             <SelectMui
+              open={open}
+              onOpen={() => setOpen(true)}
+              onClose={() => setOpen(false)}
               size="small"
               onChange={(e: any) => {
                 setSize(+e.target.value);
@@ -387,7 +398,7 @@ const Table: React.FC<TableProps> = ({
         maxHeight={maxHeight}
         minHeight={(!data || data.length === 0) && !loading ? 360 : loading ? 400 : 150}
         height={heightTable}
-        className={(data && data.length !== 0) ? "table-wrapper" : ""}
+        className={data && data.length !== 0 ? "table-wrapper" : ""}
         loading={loading ? 1 : 0}
       >
         <TableFullWidth ref={tableRef}>

--- a/src/pages/RegistrationPools/RegistrationPools.test.tsx
+++ b/src/pages/RegistrationPools/RegistrationPools.test.tsx
@@ -56,7 +56,7 @@ describe("RegistrationPools component", () => {
     const mockUseParams = useParams as jest.Mock;
     mockUseParams.mockReturnValue({ poolType: POOL_TYPE.DEREREGISTRATION });
     render(<RegistrationPools />);
-    expect(screen.getByText(/Pool De-Registration/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pool Deregistration/i)).toBeInTheDocument();
   });
 
   it("rendering table on PC with data", () => {


### PR DESCRIPTION
## Description

Position of Page Size Select is wrong when unfocused Page input (device width < 900px).
How to reappear bug?
 - On Ipad Pro in Epochs screen, focus on Page Input.
 - Click to Page Size Select and see the error displayed.

Video:
https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/69068214-2d5f-4220-b26f-b21e5324123f

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No Jira ticket link

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

No change

#### Safari

No change

#### Responsive

| Before | After |
| -------- | -------- |
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/3beee712-cae4-4acc-ae7e-c01e7db89dec) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/89c834cb-4b49-4a7c-bf77-dd78279620da) |