### PR TITLE
Bugfix/met 615 composer report was not in the right position conflict

### DIFF
--- a/src/pages/DelegatorLifecycle/index.tsx
+++ b/src/pages/DelegatorLifecycle/index.tsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress, useTheme } from "@mui/material";
+import { CircularProgress, useTheme } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router";
 import { useSelector } from "react-redux";
@@ -30,7 +30,8 @@ import {
   StakeId,
   AddressLine,
   StyledContainer,
-  Label
+  Label,
+  ReportButtonContainer
 } from "./styles";
 
 interface Params {
@@ -133,11 +134,11 @@ const DelegatorLifecycle = () => {
               </SwitchGroup>
             </BoxSwitchContainer>
             <CustomTooltip title={!isLoggedIn ? "Please log in to use this feature" : ""}>
-              <Box sx={{ [theme.breakpoints.down("sm")]: { width: "100%" } }}>
+              <ReportButtonContainer>
                 <ButtonReport disabled={!isLoggedIn} onClick={() => setOpen(true)} sidebar={+sidebar}>
                   Compose report
                 </ButtonReport>
-              </Box>
+              </ReportButtonContainer>
             </CustomTooltip>
           </BoxItemStyled>
         </BoxContainerStyled>

--- a/src/pages/DelegatorLifecycle/styles.ts
+++ b/src/pages/DelegatorLifecycle/styles.ts
@@ -134,3 +134,7 @@ export const ButtonReport = styled(Button)<{ sidebar?: number }>(({ theme }) => 
     width: "100%"
   }
 }));
+
+export const ReportButtonContainer = styled(Box)(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: { width: "100%" }
+}));

--- a/src/pages/SPOLifecycle/index.tsx
+++ b/src/pages/SPOLifecycle/index.tsx
@@ -2,7 +2,7 @@
 import { useHistory, useParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { Box, CircularProgress, useTheme } from "@mui/material";
+import { CircularProgress, useTheme } from "@mui/material";
 
 import { getShortWallet } from "src/commons/utils/helper";
 import CopyButton from "src/components/commons/CopyButton";
@@ -31,7 +31,8 @@ import {
   StakeId,
   AddressLine,
   StyledContainer,
-  Label
+  Label,
+  ReportButtonContainer
 } from "./styles";
 
 interface Params {
@@ -133,11 +134,11 @@ const SPOLifecycle = () => {
               </SwitchGroup>
             </BoxSwitchContainer>
             <CustomTooltip title={!isLoggedIn ? "Please log in to use this feature" : ""}>
-              <Box sx={{ [theme.breakpoints.down("sm")]: { width: "100%" } }}>
+              <ReportButtonContainer>
                 <ButtonReport disabled={!isLoggedIn} onClick={() => setOpen(true)} sidebar={+sidebar}>
                   Compose report
                 </ButtonReport>
-              </Box>
+              </ReportButtonContainer>
             </CustomTooltip>
           </BoxItemStyled>
         </BoxContainerStyled>

--- a/src/pages/SPOLifecycle/styles.ts
+++ b/src/pages/SPOLifecycle/styles.ts
@@ -134,3 +134,7 @@ export const ButtonReport = styled(Button)<{ sidebar?: number }>(({ theme }) => 
     width: "100%"
   }
 }));
+
+export const ReportButtonContainer = styled(Box)(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: { width: "100%" }
+}));


### PR DESCRIPTION
## Description

bugfix:MET-615 the "Composer Report" button was not in the right position

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![Image_20230626_111151_476](https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/b9eb0f35-2e89-4de7-9f3a-f0bf4f77d05b)


##### _After_

<img width="366" alt="Screenshot 2023-06-27 at 18 17 51" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/113321973/59c670fe-c0d4-4fe9-9624-9e0cc5cb78be">




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ