### PR TITLE
fix: Do-not-auto-close-search-section-when-user-click-outside

### DIFF
--- a/src/components/commons/Layout/Header/index.tsx
+++ b/src/components/commons/Layout/Header/index.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Box } from "@mui/material";
 
 import { LogoIcon, SearchIcon } from "src/commons/resources";
 import { setSidebar } from "src/stores/user";
@@ -42,6 +43,16 @@ const Header: React.FC<RouteComponentProps> = (props) => {
     `${history.location.pathname}/`.includes(subPath)
   );
 
+  const refElement = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = () => {
+      setOpenSearch(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
   return (
     <HeaderContainer data-testid="header">
       <HeaderBox home={home ? 1 : 0}>
@@ -69,7 +80,9 @@ const Header: React.FC<RouteComponentProps> = (props) => {
           </SideBarRight>
         </HeaderTop>
       </HeaderBox>
-      <TopSearch open={openSearch} onClose={setOpenSearch} />
+      <Box ref={refElement}>
+        <TopSearch open={openSearch} onClose={setOpenSearch} />
+      </Box>
     </HeaderContainer>
   );
 };


### PR DESCRIPTION
## Description

Do not automatically close search section when user click outside, expect it's need to close when user click outside

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/c2f9a0e3-e2a9-4570-8e3e-b0222011c2f2)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/e0e7cca8-23a5-4c44-8eb1-f24277219a99)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/77edf99a-b902-4916-8dc4-b109fe7111a2)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/49416fdd-ef21-40ba-a707-8d6ac26177f1)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ