### PR TITLE
fix:MET-615-private-note-show-tooltip-wrong-place

### DIFF
--- a/src/pages/PrivateNotes/styles.ts
+++ b/src/pages/PrivateNotes/styles.ts
@@ -107,7 +107,7 @@ export const ActionButton = styled("button")<{ typeButton: string }>`
 `;
 
 export const StyledLink = styled(Link)`
-  display: block;
+  display: inline;
   text-decoration: none;
   font-family: var(--font-family-text);
   color: ${(props) => props.theme.palette.secondary.main} !important;


### PR DESCRIPTION
## Description

user profile -> private note currently show tooltip in center of first row in table in, it's must be center of text

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6f18c8f3-6361-4db9-9936-696e410a0496)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/2721aa59-dae6-42cb-a09c-86f236369f76)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6587ffeb-c547-4754-95b8-bfb3052c62fa)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8c1ded02-50af-4292-81de-d1a6f4dface7)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ