### PR TITLE
bugfix:MET-615 When you click on the Total Pools tab, navigate to the latest Epoch detail.

### DIFF
--- a/src/components/DelegationPool/DelegationOverview/index.tsx
+++ b/src/components/DelegationPool/DelegationOverview/index.tsx
@@ -136,9 +136,9 @@ const OverViews: React.FC = () => {
           <StyledCard.Container>
             <StyledCard.Content>
               <StyledCard.Title>Total Pools</StyledCard.Title>
-              <StyledCard.Link to={details.epoch(data?.epochNo)}>
+              <StyledCard.Value>
                 {(data?.activePools ? +data.activePools : 0) + (data?.retiredPools ? +data.retiredPools : 0)}
-              </StyledCard.Link>
+              </StyledCard.Value>
               <Box
                 component="span"
                 sx={{ color: (theme) => theme.palette.grey[400], textAlign: "left" }}


### PR DESCRIPTION
## Description

When you click on the Total Pools tab, navigate to the latest Epoch detail.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ