### PR TITLE
bugfix:MET-615 remove tooltip lowest highest balance on token detail

### DIFF
--- a/src/components/TokenDetail/TokenAnalytics/index.tsx
+++ b/src/components/TokenDetail/TokenAnalytics/index.tsx
@@ -14,7 +14,6 @@ import { HighestIcon, LowestIcon } from "../../../commons/resources";
 import { API } from "../../../commons/utils/api";
 import { formatPrice, numberWithCommas } from "../../../commons/utils/helper";
 import Card from "../../commons/Card";
-import CustomTooltip from "../../commons/CustomTooltip";
 import {
   BoxInfo,
   BoxInfoItem,
@@ -158,11 +157,9 @@ const AddressAnalytics: React.FC = () => {
                       <img src={HighestIcon} alt="heighest icon" />
                       <Title>Highest Volume</Title>
                     </Box>
-                    <CustomTooltip title={numberWithCommas(maxBalance.value || 0)}>
-                      <ValueInfo>
-                        {loading ? <SkeletonUI variant="rectangular" /> : numberWithCommas(maxBalance.value || 0)}
-                      </ValueInfo>
-                    </CustomTooltip>
+                    <ValueInfo>
+                      {loading ? <SkeletonUI variant="rectangular" /> : numberWithCommas(maxBalance.value || 0)}
+                    </ValueInfo>
                   </Box>
                 </BoxInfoItemRight>
               </Box>
@@ -173,11 +170,9 @@ const AddressAnalytics: React.FC = () => {
                       <img src={LowestIcon} alt="lowest icon" />
                       <Title>Lowest Volume</Title>
                     </Box>
-                    <CustomTooltip title={numberWithCommas(minBalance.value || 0)}>
-                      <ValueInfo>
-                        {loading ? <SkeletonUI variant="rectangular" /> : numberWithCommas(minBalance.value || 0)}
-                      </ValueInfo>
-                    </CustomTooltip>
+                    <ValueInfo>
+                      {loading ? <SkeletonUI variant="rectangular" /> : numberWithCommas(minBalance.value || 0)}
+                    </ValueInfo>
                   </Box>
                 </BoxInfoItem>
               </Box>


### PR DESCRIPTION
## Description

 remove tooltip lowest highest balance on token detail

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ