### PR TITLE
fix: MET-1391-finding-3-Logout-still-display-account-overview

### DIFF
--- a/src/components/commons/ConnectedProfileOptionNormalLogin/index.tsx
+++ b/src/components/commons/ConnectedProfileOptionNormalLogin/index.tsx
@@ -46,6 +46,8 @@ const ConnectedProfileOptionNormalLogin: React.FC<IProps> = ({ userData }) => {
       setUser({ ...user, userData: {} });
       if (window.location.pathname.includes("report-generated")) {
         history.push(routers.STAKING_LIFECYCLE);
+      } else if (window.location.pathname.includes("/account/profile")) {
+        history.push(routers.HOME);
       } else {
         window.location.reload();
       }


### PR DESCRIPTION
## Description

When user in the account overview page and log out successfully. We expect to redirected to the home page of the application

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1391](https://cardanofoundation.atlassian.net/browse/MET-1391)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/feef9757-8f5c-4308-9224-fa6de2498450)


##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/cfd29c25-9917-4315-a469-52b14f375e1e)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1391]: https://cardanofoundation.atlassian.net/browse/MET-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ