### PR TITLE
fix: Epoch-detail-missing-text-in-header-table

### DIFF
--- a/src/components/EpochDetail/EpochBlockList/index.tsx
+++ b/src/components/EpochDetail/EpochBlockList/index.tsx
@@ -64,7 +64,7 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
       )
     },
     {
-      title: "Slot",
+      title: "Epoch / Slot",
       key: "slot",
       minWidth: "100px",
       render: (r) => (


### PR DESCRIPTION
## Description

Epoch detail missing text in header table, header "Slot" must be "Epoch / Slot"

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6c1b513b-edda-48d2-8197-9cd5efc5acc6)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/32a95c9d-d6b4-4b48-b2e3-8dbbd707ba77)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ