### PR TITLE
fix: MET-1269-BugUI-when-click-hyperlink-what-is-staking-on-cardano

### DIFF
--- a/src/components/InfoGraphicModal/styles.ts
+++ b/src/components/InfoGraphicModal/styles.ts
@@ -3,4 +3,7 @@ import { styled } from "@mui/material";
 export const Image = styled("img")`
   max-height: 80vh;
   max-width: 100%;
+  min-width: min(70vw, 50vh);
+  min-height: min(100vw, 80vh);
+  aspect-ratio: 50/71;
 `;


### PR DESCRIPTION
## Description

Bug UI when click hyperlink what is staking on cardano,  flashing squares appear
## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1269](https://cardanofoundation.atlassian.net/browse/MET-1269)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1269]: https://cardanofoundation.atlassian.net/browse/MET-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ