### PR TITLE
fix: MET-1414-change-text-in-epoch-overview-page(Finding-3,4,5,6)

### DIFF
--- a/src/components/EpochDetail/EpochBlockList/index.tsx
+++ b/src/components/EpochDetail/EpochBlockList/index.tsx
@@ -77,6 +77,12 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
       )
     },
     {
+      title: "Created At",
+      key: "time",
+      minWidth: "100px",
+      render: (r) => <PriceWrapper>{formatDateTimeLocal(r.time)}</PriceWrapper>
+    },
+    {
       title: "Transactions",
       key: "blkCount",
       minWidth: "100px",
@@ -102,12 +108,6 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
           <ADAicon />
         </StyledOutput>
       )
-    },
-    {
-      title: "Created At",
-      key: "time",
-      minWidth: "100px",
-      render: (r) => <PriceWrapper>{formatDateTimeLocal(r.time)}</PriceWrapper>
     }
   ];
 

--- a/src/components/EpochDetail/EpochOverview/index.tsx
+++ b/src/components/EpochDetail/EpochOverview/index.tsx
@@ -34,7 +34,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       icon: timeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>Start time </TitleCard>
+          <TitleCard mr={1}>Start Timestamp </TitleCard>
         </Box>
       ),
       value: formatDateTimeLocal(data?.startTime || "")
@@ -43,7 +43,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       icon: timeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>End time </TitleCard>
+          <TitleCard mr={1}>End Timestamp </TitleCard>
         </Box>
       ),
       value: formatDateTimeLocal(data?.endTime || "")
@@ -65,7 +65,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       icon: cubeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> Block</TitleCard>
+          <TitleCard mr={1}> Blocks</TitleCard>
         </Box>
       ),
       value: data?.blkCount || 0

--- a/src/components/EpochDetail/EpochOverview/index.tsx
+++ b/src/components/EpochDetail/EpochOverview/index.tsx
@@ -65,7 +65,7 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
       icon: cubeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> Block</TitleCard>
+          <TitleCard mr={1}> Blocks</TitleCard>
         </Box>
       ),
       value: data?.blkCount || 0

--- a/src/components/commons/Epoch/FirstEpoch/index.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/index.tsx
@@ -52,10 +52,28 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
       )
     },
     {
+      icon: timeIconUrl,
+      title: (
+        <Box display={"flex"} alignItems="center">
+          <TitleCard mr={1}> Start Timestamp</TitleCard>
+        </Box>
+      ),
+      value: <Content>{formatDateTimeLocal(currentEpochData?.startTime || "")}</Content>
+    },
+    {
+      icon: timeIconUrl,
+      title: (
+        <Box display={"flex"} alignItems="center">
+          <TitleCard mr={1}> End Timestamp</TitleCard>
+        </Box>
+      ),
+      value: <Content>{formatDateTimeLocal(currentEpochData?.endTime || "")}</Content>
+    },
+    {
       icon: cubeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>Block </TitleCard>
+          <TitleCard mr={1}>Blocks </TitleCard>
         </Box>
       ),
       value: <Content>{currentEpochData?.blkCount}</Content>
@@ -75,24 +93,6 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
           <SubContent>/{MAX_SLOT_EPOCH}</SubContent>
         </Content>
       )
-    },
-    {
-      icon: timeIconUrl,
-      title: (
-        <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> Start Time</TitleCard>
-        </Box>
-      ),
-      value: <Content>{formatDateTimeLocal(currentEpochData?.startTime || "")}</Content>
-    },
-    {
-      icon: timeIconUrl,
-      title: (
-        <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> End Time</TitleCard>
-        </Box>
-      ),
-      value: <Content>{formatDateTimeLocal(currentEpochData?.endTime || "")}</Content>
     }
   ];
   return (

--- a/src/components/commons/Epoch/FirstEpoch/index.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/index.tsx
@@ -52,10 +52,28 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
       )
     },
     {
+      icon: timeIconUrl,
+      title: (
+        <Box display={"flex"} alignItems="center">
+          <TitleCard mr={1}> Start Time</TitleCard>
+        </Box>
+      ),
+      value: <Content>{formatDateTimeLocal(currentEpochData?.startTime || "")}</Content>
+    },
+    {
+      icon: timeIconUrl,
+      title: (
+        <Box display={"flex"} alignItems="center">
+          <TitleCard mr={1}> End Time</TitleCard>
+        </Box>
+      ),
+      value: <Content>{formatDateTimeLocal(currentEpochData?.endTime || "")}</Content>
+    },
+    {
       icon: cubeIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>Block </TitleCard>
+          <TitleCard mr={1}>Blocks </TitleCard>
         </Box>
       ),
       value: <Content>{currentEpochData?.blkCount}</Content>
@@ -75,24 +93,6 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
           <SubContent>/{MAX_SLOT_EPOCH}</SubContent>
         </Content>
       )
-    },
-    {
-      icon: timeIconUrl,
-      title: (
-        <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> Start Time</TitleCard>
-        </Box>
-      ),
-      value: <Content>{formatDateTimeLocal(currentEpochData?.startTime || "")}</Content>
-    },
-    {
-      icon: timeIconUrl,
-      title: (
-        <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}> End Time</TitleCard>
-        </Box>
-      ),
-      value: <Content>{formatDateTimeLocal(currentEpochData?.endTime || "")}</Content>
     }
   ];
   return (

--- a/src/pages/Epoch/index.tsx
+++ b/src/pages/Epoch/index.tsx
@@ -48,6 +48,23 @@ const Epoch: React.FC = () => {
       )
     },
     {
+      title: "Start Time",
+      key: "startTime",
+      minWidth: "100px",
+      render: (r) => <BlueText>{formatDateTimeLocal(r.startTime || "")}</BlueText>
+    },
+    {
+      title: "End Time",
+      key: "endTime",
+      minWidth: "100px",
+      render: (r) => (
+        <BlueText>
+          {formatDateTimeLocal(r.endTime || "")}
+          {epoch === r.no && <SelectedIcon />}
+        </BlueText>
+      )
+    },
+    {
       title: "Blocks",
       key: "blkCount",
       minWidth: "100px",
@@ -92,23 +109,6 @@ const Epoch: React.FC = () => {
       sort: ({ columnKey, sortValue }) => {
         sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
       }
-    },
-    {
-      title: "Start Timestamp",
-      key: "startTime",
-      minWidth: "100px",
-      render: (r) => <BlueText>{formatDateTimeLocal(r.startTime || "")}</BlueText>
-    },
-    {
-      title: "End Timestamp",
-      key: "endTime",
-      minWidth: "100px",
-      render: (r) => (
-        <BlueText>
-          {formatDateTimeLocal(r.endTime || "")}
-          {epoch === r.no && <SelectedIcon />}
-        </BlueText>
-      )
     }
   ];
 

--- a/src/pages/Epoch/index.tsx
+++ b/src/pages/Epoch/index.tsx
@@ -48,6 +48,23 @@ const Epoch: React.FC = () => {
       )
     },
     {
+      title: "Start Timestamp",
+      key: "startTime",
+      minWidth: "100px",
+      render: (r) => <BlueText>{formatDateTimeLocal(r.startTime || "")}</BlueText>
+    },
+    {
+      title: "End Timestamp",
+      key: "endTime",
+      minWidth: "100px",
+      render: (r) => (
+        <BlueText>
+          {formatDateTimeLocal(r.endTime || "")}
+          {epoch === r.no && <SelectedIcon />}
+        </BlueText>
+      )
+    },
+    {
       title: "Blocks",
       key: "blkCount",
       minWidth: "100px",
@@ -92,23 +109,6 @@ const Epoch: React.FC = () => {
       sort: ({ columnKey, sortValue }) => {
         sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
       }
-    },
-    {
-      title: "Start Timestamp",
-      key: "startTime",
-      minWidth: "100px",
-      render: (r) => <BlueText>{formatDateTimeLocal(r.startTime || "")}</BlueText>
-    },
-    {
-      title: "End Timestamp",
-      key: "endTime",
-      minWidth: "100px",
-      render: (r) => (
-        <BlueText>
-          {formatDateTimeLocal(r.endTime || "")}
-          {epoch === r.no && <SelectedIcon />}
-        </BlueText>
-      )
     }
   ];
 


### PR DESCRIPTION
## Description

2. Replace “Start time” for “Start Timestamp” and “End Time” for “End Timestamp“ on the cards/dashboard to keep consistency with the column headers.
 3. Move the “Start Timestamp“ and “End Timestamp“columns' positions for second and third on the cards/dashboard and also on the table. 

Hence, we will have the following: 
On the cards/dashboard: Epoch Number, Start Timestamp, End Timestamp, Blocks and Slot
On the table: Epoch Number, Start Timestamp, End Timestamp, Blocks and etc… 

4. Rename “Block“ per “Blocks“, as it’s the number of blocks in an epoch.
 5. Rename “Block“ per “Blocks“, as it’s the number of blocks in an epoch.
 6. Replace “Start time” for “Start Timestamp” and “End Time” for “End Timestamp“ on the cards/dashboard

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1414](https://cardanofoundation.atlassian.net/browse/MET-1414)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6c27b4d8-fb2d-418b-ac26-9a6cdbfe785e)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/13b45198-7fb0-4309-9f74-5810b2dd8575)

##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/c2406212-194d-4c57-b428-dfc616a6f93f)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/bc731de5-ed79-4b5e-af26-f118a225fa00)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1414]: https://cardanofoundation.atlassian.net/browse/MET-1414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ