### PR TITLE
bugfix/MET-265-display-saturation-process

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { Box } from "@mui/material";
+import { get } from "lodash";
 
 import Table, { Column } from "src/components/commons/Table";
 import { formatADAFull, formatPercent, getPageInfo, getShortWallet } from "src/commons/utils/helper";
@@ -114,7 +115,7 @@ const DelegationLists: React.FC = () => {
       render: (r) => (
         <Box display="flex" alignItems="center" justifyContent={"space-between"}>
           <Box component={"span"}>{formatPercent(r.saturation / 100) || `0%`}</Box>
-          <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : r.saturation} />
+          <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : get(r, "saturation", 0)} />
         </Box>
       )
     },

--- a/src/components/Home/TopDelegationPools/index.tsx
+++ b/src/components/Home/TopDelegationPools/index.tsx
@@ -1,5 +1,6 @@
 import { useHistory } from "react-router-dom";
 import { Box } from "@mui/material";
+import { get } from "lodash";
 
 import useFetch from "src/commons/hooks/useFetch";
 import { details, routers } from "src/commons/routers";
@@ -62,7 +63,7 @@ const TopDelegationPools = () => {
       render: (r) => (
         <Box display="flex" alignItems="center" justifyContent={"space-between"}>
           <Box component={"span"}>{formatPercent(r.saturation / 100) || `0%`}</Box>
-          <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : r.saturation} />
+          <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : get(r, "saturation", 0)} />
         </Box>
       )
     },


### PR DESCRIPTION
## Description

MET-265 display satuaration

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-265](https://cardanofoundation.atlassian.net/browse/MET-265)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
Before
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/04619f21-daf0-4f91-9a0e-e524a729f9cf)

After
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/09532595-cd75-4abf-aac7-da8509289cd4)


[MET-265]: https://cardanofoundation.atlassian.net/browse/MET-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ