### PR TITLE
fix: MET-1415-change-text-in-block-overview-page

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -52,7 +52,9 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
       icon: txConfirmUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>Confirmation</TitleCard>
+          <TitleCard mr={1}>
+            {data?.confirmation && data?.confirmation > 1 ? "Confirmations" : "Confirmation"}
+          </TitleCard>
         </Box>
       ),
       value: (
@@ -66,7 +68,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
       icon: exchageIconUrl,
       title: (
         <Box display={"flex"} alignItems="center">
-          <TitleCard mr={1}>Transaction</TitleCard>
+          <TitleCard mr={1}>{data?.txCount && data?.txCount > 1 ? "Transactions" : "Transaction"}</TitleCard>
         </Box>
       ),
       value: data?.txCount || 0

--- a/src/components/TransactionListsFull/index.tsx
+++ b/src/components/TransactionListsFull/index.tsx
@@ -62,6 +62,15 @@ const TransactionListFull: React.FC<TransactionListFullProps> = ({
           <CustomTooltip title={r.hash}>
             <StyledLink to={details.transaction(r.hash)}>{getShortHash(r.hash)}</StyledLink>
           </CustomTooltip>
+        </div>
+      )
+    },
+    {
+      title: "Created At",
+      key: "createdat",
+      minWidth: 120,
+      render: (r) => (
+        <div>
           <Box mt={1}>{formatDateTimeLocal(r.time || "")}</Box>
         </div>
       )

--- a/src/pages/BlockList/index.tsx
+++ b/src/pages/BlockList/index.tsx
@@ -63,6 +63,15 @@ const BlockList = () => {
       )
     },
     {
+      title: "Created At",
+      key: "time",
+      minWidth: "100px",
+      render: (r) => <PriceWrapper>{formatDateTimeLocal(r.time)}</PriceWrapper>,
+      sort: ({ columnKey, sortValue }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
+      }
+    },
+    {
       title: "Transactions",
       key: "txCount",
       minWidth: "50px",
@@ -92,15 +101,6 @@ const BlockList = () => {
           {block === (r.blockNo || r.hash) && <SelectedIcon />}
         </PriceWrapper>
       )
-    },
-    {
-      title: "Created At",
-      key: "time",
-      minWidth: "100px",
-      render: (r) => <PriceWrapper>{formatDateTimeLocal(r.time)}</PriceWrapper>,
-      sort: ({ columnKey, sortValue }) => {
-        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
-      }
     }
   ];
 


### PR DESCRIPTION
## Description

1. Move “Created at” to column 4, This way we will have “Created At“ between “Epoch/Slot” and “Transactions”
2. If more than 1, replace “Confirmation“ for “Confirmations” and “Transaction“ for “Transactions“. Remove
3. - Create a third column besides Tx Hash. 

-Date/time will be between “TX Hash“ and “Blocks“ and header will be called “Created At“

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1415](https://cardanofoundation.atlassian.net/browse/MET-1415)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/1513a837-afc1-4fd0-b72e-7adbaf7b5abc)


##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/904b8cae-6887-4d45-a357-f30311c751d4)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1415]: https://cardanofoundation.atlassian.net/browse/MET-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ