### PR TITLE
fix: MET-615-prevent-collapse-when-close-sidebar

### DIFF
--- a/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
+++ b/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
@@ -52,22 +52,23 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
   }, [sidebar]);
 
   useEffect(() => {
-    if (pathname === "/") {
+    if (pathname === "/" || !sidebar) {
       setActive(null);
     } else if (
-      pathname.startsWith("/stake/") ||
-      pathname.startsWith("/transaction/") ||
-      pathname.startsWith("/stake-key/") ||
-      pathname.startsWith("/block/") ||
-      pathname.startsWith("/epoch/") ||
-      pathname.startsWith("/token/") ||
-      pathname.startsWith("/contracts/") ||
-      pathname.startsWith("/delegation-pool/") ||
-      pathname.startsWith("/policy/")
+      sidebar &&
+      (pathname.startsWith("/stake/") ||
+        pathname.startsWith("/transaction/") ||
+        pathname.startsWith("/stake-key/") ||
+        pathname.startsWith("/block/") ||
+        pathname.startsWith("/epoch/") ||
+        pathname.startsWith("/token/") ||
+        pathname.startsWith("/contracts/") ||
+        pathname.startsWith("/delegation-pool/") ||
+        pathname.startsWith("/policy/"))
     ) {
       setActive("menu-0");
     }
-  }, [pathname]);
+  }, [pathname, sidebar]);
 
   useEffect(() => {
     if (!sidebar && width >= theme.breakpoints.values.md) setSidebar(true);


### PR DESCRIPTION
## Description

Prevent collapse when close sidebar

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="173" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/48188ade-07c2-4611-a90b-9f732ee841dc">


##### _After_

[comment]: <> (Add screenshots)
<img width="351" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a89255f4-7456-41c6-95f2-cc37601b8249">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ