### PR TITLE
fix: MET-1415-finding-3-remove-tag-low-high-medium-in-card-confirmation

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -11,11 +11,11 @@ import {
   slotIconUrl
 } from "src/commons/resources";
 import { formatADAFull, formatDateTimeLocal } from "src/commons/utils/helper";
-import { CONFIRMATION_STATUS, MAX_SLOT_EPOCH } from "src/commons/utils/constants";
+import { MAX_SLOT_EPOCH } from "src/commons/utils/constants";
 import ADAicon from "src/components/commons/ADAIcon";
 import DetailHeader from "src/components/commons/DetailHeader";
 
-import { ConfirmStatus, Subtext, TitleCard, WrapConfirmation } from "./styles";
+import { Subtext, TitleCard, WrapConfirmation } from "./styles";
 
 interface BlockOverviewProps {
   data: BlockDetail | null;
@@ -25,18 +25,6 @@ interface BlockOverviewProps {
 
 const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdated }) => {
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
-
-  const renderConfirmationTag = () => {
-    if (data && data.confirmation) {
-      if (data.confirmation <= 2) {
-        return CONFIRMATION_STATUS.LOW;
-      }
-      if (data.confirmation <= 8) {
-        return CONFIRMATION_STATUS.MEDIUM;
-      }
-      return CONFIRMATION_STATUS.HIGH;
-    }
-  };
 
   const listOverview = [
     {
@@ -55,12 +43,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
           <TitleCard mr={1}>Confirmation</TitleCard>
         </Box>
       ),
-      value: (
-        <WrapConfirmation>
-          {data?.confirmation || 0}
-          <ConfirmStatus status={renderConfirmationTag() || "LOW"}>{renderConfirmationTag() || "LOW"}</ConfirmStatus>
-        </WrapConfirmation>
-      )
+      value: <WrapConfirmation>{data?.confirmation || 0}</WrapConfirmation>
     },
     {
       icon: exchageIconUrl,

--- a/src/components/TransactionDetail/TransactionOverview/index.tsx
+++ b/src/components/TransactionDetail/TransactionOverview/index.tsx
@@ -14,7 +14,7 @@ import {
   txOutputIconUrl
 } from "src/commons/resources";
 import { formatADAFull, formatDateTimeLocal, getShortWallet } from "src/commons/utils/helper";
-import { CONFIRMATION_STATUS, MAX_SLOT_EPOCH } from "src/commons/utils/constants";
+import { MAX_SLOT_EPOCH } from "src/commons/utils/constants";
 import { details } from "src/commons/routers";
 import { RootState } from "src/stores/types";
 import { useScreen } from "src/commons/hooks/useScreen";
@@ -24,7 +24,7 @@ import DropdownDetail from "src/components/commons/DropdownDetail";
 import CustomTooltip from "src/components/commons/CustomTooltip";
 import ADAicon from "src/components/commons/ADAIcon";
 
-import { ConfirmStatus, MaxSlot, StyledLink, TitleCard } from "./styles";
+import { MaxSlot, StyledLink, TitleCard } from "./styles";
 
 interface Props {
   data: Transaction | null;
@@ -38,18 +38,6 @@ const TransactionOverview: React.FC<Props> = ({ data, loading, lastUpdated }) =>
   const [openListOutput, setOpenListOutput] = useState(false);
   const theme = useTheme();
   const { isMobile } = useScreen();
-
-  const renderConfirmationTag = () => {
-    if (data && data.tx && data.tx.confirmation) {
-      if (data.tx.confirmation <= 2) {
-        return CONFIRMATION_STATUS.LOW;
-      }
-      if (data.tx.confirmation <= 8) {
-        return CONFIRMATION_STATUS.MEDIUM;
-      }
-      return CONFIRMATION_STATUS.HIGH;
-    }
-  };
 
   const inputTransaction = useMemo(() => {
     const result = [];
@@ -181,12 +169,7 @@ const TransactionOverview: React.FC<Props> = ({ data, loading, lastUpdated }) =>
           </TitleCard>
         </Box>
       ),
-      value: (
-        <>
-          {data?.tx?.confirmation || 0}
-          <ConfirmStatus status={renderConfirmationTag() || "LOW"}>{renderConfirmationTag() || "LOW"}</ConfirmStatus>
-        </>
-      )
+      value: <>{data?.tx?.confirmation || 0}</>
     },
     {
       icon: totalOutputUrl,

--- a/src/components/commons/ConnectedProfileOption/index.tsx
+++ b/src/components/commons/ConnectedProfileOption/index.tsx
@@ -24,7 +24,7 @@ const ConnectedProfileOption: React.FC<IProps> = ({ isConnected, disconnect, sta
   const history = useHistory();
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
-    setOnDetailView(false)
+    setOnDetailView(false);
   };
 
   const handleClose = () => {

--- a/src/components/commons/DetailView/DetailViewBlock.tsx
+++ b/src/components/commons/DetailView/DetailViewBlock.tsx
@@ -3,7 +3,7 @@ import { CgArrowsExchange, CgClose } from "react-icons/cg";
 import { useSelector } from "react-redux";
 import { BiChevronRight } from "react-icons/bi";
 
-import { CONFIRMATION_STATUS, MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
+import { MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
 import { CubeIcon, RocketIcon } from "src/commons/resources";
 import useFetch from "src/commons/hooks/useFetch";
 import { details } from "src/commons/routers";
@@ -39,7 +39,6 @@ import {
   StyledLink,
   DetailLinkName,
   ViewDetailHeader,
-  ConfirmStatus,
   ViewDetailScroll,
   TimeDuration
 } from "./styles";
@@ -64,19 +63,6 @@ const DetailViewBlock: React.FC<DetailViewBlockProps> = (props) => {
     REFRESH_TIMES.BLOCK_DETAIL
   );
   const { currentEpoch } = useSelector(({ system }: RootState) => system);
-
-  const renderConfirmationTag = () => {
-    if (data?.confirmation) {
-      if (data.confirmation <= 2) {
-        return CONFIRMATION_STATUS.LOW;
-      }
-      if (data.confirmation <= 8) {
-        return CONFIRMATION_STATUS.MEDIUM;
-      }
-      return CONFIRMATION_STATUS.HIGH;
-    }
-    return CONFIRMATION_STATUS.LOW;
-  };
 
   useEffect(() => {
     document.body.style.overflowY = "hidden";
@@ -215,10 +201,7 @@ const DetailViewBlock: React.FC<DetailViewBlockProps> = (props) => {
             </DetailsInfoItem>
             <DetailsInfoItem>
               <DetailLabel>Confirmation</DetailLabel>
-              <DetailValue>
-                {data.confirmation}
-                <ConfirmStatus status={renderConfirmationTag()}>{renderConfirmationTag()}</ConfirmStatus>
-              </DetailValue>
+              <DetailValue>{data.confirmation}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
               <DetailLabel>Transaction Fees</DetailLabel>

--- a/src/components/commons/DetailView/DetailViewTransaction.tsx
+++ b/src/components/commons/DetailView/DetailViewTransaction.tsx
@@ -3,7 +3,7 @@ import { CgArrowsExchange, CgClose } from "react-icons/cg";
 import { BiChevronRight } from "react-icons/bi";
 import { useSelector } from "react-redux";
 
-import { CONFIRMATION_STATUS, MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
+import { MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
 import {
   CubeIcon,
   DelegationHistoryMainIcon,
@@ -53,7 +53,6 @@ import {
   DetailLinkRight,
   StyledLink,
   TxStatus,
-  ConfirmStatus,
   DetailLinkName,
   DetailLinkImage,
   ViewDetailScroll,
@@ -166,19 +165,6 @@ const DetailViewTransaction: React.FC<DetailViewTransactionProps> = (props) => {
   const input = data.utxOs?.inputs[0]?.address || "";
   const output = data.utxOs?.outputs[0]?.address || "";
 
-  const renderConfirmationTag = () => {
-    if (data?.tx?.confirmation) {
-      if (data.tx.confirmation <= 2) {
-        return CONFIRMATION_STATUS.LOW;
-      }
-      if (data.tx.confirmation <= 8) {
-        return CONFIRMATION_STATUS.MEDIUM;
-      }
-      return CONFIRMATION_STATUS.HIGH;
-    }
-    return CONFIRMATION_STATUS.LOW;
-  };
-
   return (
     <ViewDetailDrawer anchor="right" open={!!hash} hideBackdrop variant="permanent">
       <ViewDetailHeader>
@@ -270,10 +256,7 @@ const DetailViewTransaction: React.FC<DetailViewTransactionProps> = (props) => {
             </DetailsInfoItem>
             <DetailsInfoItem>
               <DetailLabel>Confirmation</DetailLabel>
-              <DetailValue>
-                {data.tx.confirmation}
-                <ConfirmStatus status={renderConfirmationTag()}>{renderConfirmationTag()}</ConfirmStatus>
-              </DetailValue>
+              <DetailValue>{data.tx.confirmation}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
               <DetailLabel>Transaction Fees</DetailLabel>


### PR DESCRIPTION
## Description

Remove tag Low, High, Medium in card Confirmation at all page:  block, block list, transaction, transaction page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1415](https://cardanofoundation.atlassian.net/browse/MET-1415)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="246" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/4dbb9307-37af-458a-94bb-af4003c8084a">
<img width="644" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/34c1a9e0-b8bf-43d8-9075-9c660c5d7a85">


##### _After_

[comment]: <> (Add screenshots)
<img width="224" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/45171955-b6d5-473f-b33a-c5ac6f99b359">
<img width="506" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/dbd68dca-9458-4ae7-b076-2f359fbbc0c0">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)
<img width="269" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/f892ae1f-58dc-40a5-99ea-7e73f8757de5">


##### _After_

[comment]: <> (Add screenshots)
<img width="278" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/83d57f1e-d2ab-4c41-a9c1-47c48a83adac">


[MET-1415]: https://cardanofoundation.atlassian.net/browse/MET-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ