### PR TITLE
fix: MET-1409-Hyperlink-epoch-number

### DIFF
--- a/src/components/commons/Epoch/FirstEpoch/index.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/index.tsx
@@ -34,7 +34,13 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
     {
       icon: ExchangeIcon,
       hideHeader: true,
-      title: <EpochNumber>{currentEpochData?.no}</EpochNumber>,
+      title: (
+        <EpochNumber>
+          <Box component={"span"} onClick={handleClick}>
+            {currentEpochData?.no}
+          </Box>
+        </EpochNumber>
+      ),
       value: (
         <Box display={"flex"} alignItems="center" justifyContent={"center"} onClick={handleClick}>
           <ProgressCircle

--- a/src/components/commons/Epoch/FirstEpoch/styles.ts
+++ b/src/components/commons/Epoch/FirstEpoch/styles.ts
@@ -55,7 +55,8 @@ export const EpochNumber = styled(Box)(({ theme }) => ({
   textAlign: "center",
   [theme.breakpoints.down("sm")]: {
     marginTop: "-8px"
-  }
+  },
+  color: theme.palette.secondary.main
 }));
 
 export const TitleCard = styled(Box)(({ theme }) => ({

--- a/src/pages/Epoch/index.tsx
+++ b/src/pages/Epoch/index.tsx
@@ -17,7 +17,7 @@ import SelectedIcon from "src/components/commons/SelectedIcon";
 import Table, { Column } from "src/components/commons/Table";
 import { setOnDetailView } from "src/stores/user";
 
-import { Blocks, BlueText, Output, Status, StyledContainer } from "./styles";
+import { Blocks, BlueText, Output, Status, StyledBox, StyledContainer } from "./styles";
 
 const Epoch: React.FC = () => {
   const [epoch, setEpoch] = useState<number | null>(null);
@@ -39,9 +39,7 @@ const Epoch: React.FC = () => {
       render: (r) => (
         <Link to={details.epoch(r.no || 0)}>
           <Box textAlign="center">
-            <Box width={41} margin="auto">
-              {r.no || 0}
-            </Box>
+            <StyledBox>{r.no || 0}</StyledBox>
             <Status status={r.status.toLowerCase()}>{EPOCH_STATUS[r.status]}</Status>
           </Box>
         </Link>

--- a/src/pages/Epoch/styles.ts
+++ b/src/pages/Epoch/styles.ts
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import { styled, Container } from "@mui/material";
 
 export const StyledContainer = styled(Container)(({ theme }) => ({
@@ -45,4 +46,10 @@ export const Output = styled(Blocks)`
   display: inline-flex;
   align-items: center;
   gap: 10px;
+`;
+
+export const StyledBox = styled(Box)`
+  width: 41px;
+  margin: auto;
+  color: ${(props) => props.theme.palette.secondary.main} !important;
 `;


### PR DESCRIPTION
## Description

Hyperlinking epoch number in the Epoch list that similar to other tables

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1409](https://cardanofoundation.atlassian.net/browse/MET-1409)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="455" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a984a57c-de22-4be9-97dd-2dbf6a682ffa">


##### _After_

[comment]: <> (Add screenshots)
<img width="452" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a1e6a6b5-791d-45fe-89d6-49db63beddd4">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1409]: https://cardanofoundation.atlassian.net/browse/MET-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ