### PR TITLE
fix: MET-1416-finding-1-replace-card-time-with-created-at

### DIFF
--- a/src/components/commons/DetailView/DetailViewTransaction.tsx
+++ b/src/components/commons/DetailView/DetailViewTransaction.tsx
@@ -259,7 +259,7 @@ const DetailViewTransaction: React.FC<DetailViewTransactionProps> = (props) => {
               </DetailsInfoItem>
             )}
             <DetailsInfoItem>
-              <DetailLabel>Time</DetailLabel>
+              <DetailLabel>Create At</DetailLabel>
               <DetailValue>{formatDateTimeLocal(data.tx.time || "")}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>


### PR DESCRIPTION
## Description

Replace card "time" with "created at" in transaction page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1416](https://cardanofoundation.atlassian.net/browse/MET-1416)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="249" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ca4f7b4b-eeb0-4aa2-a914-effe183efb83">


##### _After_

[comment]: <> (Add screenshots)
<img width="230" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8daf8338-d04e-446d-b12d-1c7c6abeafa1">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1416]: https://cardanofoundation.atlassian.net/browse/MET-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ