### PR TITLE
fix: MET-615-pool-detail-button-back-lie-on-top-dropdown-search

### DIFF
--- a/src/components/commons/Layout/Header/styles.ts
+++ b/src/components/commons/Layout/Header/styles.ts
@@ -48,10 +48,6 @@ export const HeaderMain = styled("div")<{ home: number }>(({ theme, home }) => (
   position: "relative",
   textAlign: "start",
   padding: home ? "0px 0px 50px" : "27px 0px",
-  "& > div": {
-    paddingTop: home ? "0px" : "30px",
-    marginBottom: home ? "0px" : "calc(-25px - 1.5715rem)"
-  },
   [theme.breakpoints.down("md")]: {
     padding: home ? "62px 0px 48px" : 0,
     display: home ? "block" : "none"


### PR DESCRIPTION
## Description

Button back lie on top of dropdown search at pool detail pages

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/c33b551e-d832-434a-8530-03944c368eed)


##### _After_

[comment]: <> (Add screenshots)

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/f53659ff-2fa6-4ead-875d-0208ee35aa32)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ