### PR TITLE
fix: MET-1271 add column unique acocunts

### DIFF
--- a/src/components/EpochDetail/EpochOverview/EpochOverview.test.tsx
+++ b/src/components/EpochDetail/EpochOverview/EpochOverview.test.tsx
@@ -13,7 +13,8 @@ const mockedData: IDataEpoch = {
   startTime: "2023/06/09 21:47:26",
   status: "REWARDING",
   txCount: 375738,
-  epochSlotNo: 0
+  epochSlotNo: 0,
+  account: 100
 };
 
 describe("EpochOverview", () => {

--- a/src/components/commons/Epoch/FirstEpoch/FirstEpoch.test.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/FirstEpoch.test.tsx
@@ -29,7 +29,8 @@ const mockedEpochData: IDataEpoch = {
   rewardsDistributed: 0,
   endTime: mockedCurrentEpoch.endTime,
   startTime: mockedCurrentEpoch.startTime,
-  status: "IN_PROGRESS"
+  status: "IN_PROGRESS",
+  account: 100
 };
 
 describe("FirstEpoch component", () => {

--- a/src/pages/Epoch/Epoch.test.tsx
+++ b/src/pages/Epoch/Epoch.test.tsx
@@ -15,7 +15,8 @@ const mockData = [
     rewardsDistributed: null,
     startTime: "2023/06/09 21:47:26",
     status: "REWARDING",
-    txCount: 375738
+    txCount: 375738,
+    account: 100
   }
 ];
 
@@ -29,7 +30,8 @@ const mockDataLatestEpoch = [
     rewardsDistributed: null,
     startTime: "2023/06/14 21:44:54",
     status: "IN_PROGRESS",
-    txCount: 37219
+    txCount: 37219,
+    account: 100
   }
 ];
 

--- a/src/pages/Epoch/index.tsx
+++ b/src/pages/Epoch/index.tsx
@@ -74,6 +74,12 @@ const Epoch: React.FC = () => {
       }
     },
     {
+      title: "Unique Accounts",
+      key: "account",
+      minWidth: "100px",
+      render: (r) => <Blocks>{r.account}</Blocks>
+    },
+    {
       title: "Transaction Count",
       key: "transactionCount",
       minWidth: "100px",

--- a/src/types/epoch.d.ts
+++ b/src/types/epoch.d.ts
@@ -15,6 +15,7 @@ interface IDataEpoch {
   epochSlotNo: number;
   maxSlot: number;
   rewardsDistributed: number;
+  account: number;
 }
 
 interface IEpoch {


### PR DESCRIPTION
## Description

feat: add column unique accounts in epochs page

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [MET-1271](https://cardanofoundation.atlassian.net/browse/MET-1031

### Testing & Validation

- [X] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
Before
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/9e68af2c-42f3-42bf-84f7-7a4f0c5a256f)

After

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/3fa4b8a4-1355-4414-9cf4-3e2e5eb4fa83)


[MET-1271]: https://cardanofoundation.atlassian.net/browse/MET-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ