### PR TITLE
fix: pagination report detail page wrong

### DIFF
--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/DelegationTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/DelegationTab.tsx
@@ -90,7 +90,7 @@ const DelegationTab = () => {
         total={{ title: "Total", count: fetchData.total }}
         pagination={{
           ...pageInfo,
-          page: pageInfo.page + 1,
+          page: pageInfo.page,
           total: fetchData.total,
           onChange: (page, size) => setPageInfo((pre) => ({ ...pre, page: page - 1, size }))
         }}


### PR DESCRIPTION
## Description

pagination report detail page wrong default page current is 2

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/2343c03b-3514-44e1-8d60-59ca3e72bb32)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/968fed10-af41-4353-9665-4da16c37e37a)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)