### PR TITLE
fix: MET-615-Report-creation-missing-data-tab-pool-certificate

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/ReportComposerModal/FilledInfoModal.tsx
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/ReportComposerModal/FilledInfoModal.tsx
@@ -3,13 +3,12 @@ import { useHistory, useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { Box, FormControl, FormControlLabel, RadioGroup, Stack, Radio } from "@mui/material";
 
-import StyledModal from "src/components/commons/StyledModal";
-import { useScreen } from "src/commons/hooks/useScreen";
+import CustomModal from "src/components/commons/CustomModal";
 import CustomDatePicker, { IDateRange } from "src/components/CustomDatePicker";
 
 import {
   ButtonEvent,
-  ModalTitle,
+  Container,
   StyledButton,
   StyledFormLabel,
   StyledLabel,
@@ -106,7 +105,6 @@ const FilledInfoModal: React.FC<IPropsModal> = ({ open, handleCloseModal, savePa
   const reportType: ReportType = isDelegatorPage ? ReportType.StakeKeyReport : ReportType.PoolReport;
   const address = poolId || stakeId;
 
-  const { isMobile } = useScreen();
   const [dateRange, setDateRange] = useState<IDateRange>([null, null]);
   const [adaTransfers, setADATransfer] = useState<RatioGroupValue>(RatioGroupValue.unTicked);
   const [poolSize, setPoolSize] = useState<RatioGroupValue>(RatioGroupValue.unTicked);
@@ -244,17 +242,8 @@ const FilledInfoModal: React.FC<IPropsModal> = ({ open, handleCloseModal, savePa
   };
 
   return (
-    <StyledModal
-      open={open}
-      handleCloseModal={handleCloseModal}
-      paddingX={isMobile ? "10px" : "40px"}
-      paddingY={isMobile ? "20px" : "30px"}
-      contentStyle={{ overflowY: "unset", overflowX: "auto" }}
-    >
-      <Box>
-        <ModalTitle>
-          <Box sx={{ fontSize: `${isMobile ? "20px" : "24px"}` }}>Report composer</Box>
-        </ModalTitle>
+    <CustomModal open={open} onClose={handleCloseModal} title="Report composer" width={500} sx={{ overflowY: "unset" }}>
+      <Container>
         <StyledStack>
           <StyledLabel>Report name</StyledLabel>
           <StyledTextField placeholder="Enter report name" value={reportName} onChange={onChangeReportName} />
@@ -299,11 +288,13 @@ const FilledInfoModal: React.FC<IPropsModal> = ({ open, handleCloseModal, savePa
                           value={RatioGroupValue.yes}
                           control={<Radio onClick={() => handleClickRadio(key)} />}
                           label="Yes"
+                          sx={{ color: (props) => props.palette.grey[400] }}
                         />
                         <FormControlLabel
                           value={RatioGroupValue.no}
                           control={<Radio onClick={() => handleClickRadio(key)} />}
                           label="No"
+                          sx={{ color: (props) => props.palette.grey[400] }}
                         />
                       </Stack>
                     </RadioGroup>
@@ -336,8 +327,8 @@ const FilledInfoModal: React.FC<IPropsModal> = ({ open, handleCloseModal, savePa
             Next
           </StyledButton>
         </StyledStack>
-      </Box>
-    </StyledModal>
+      </Container>
+    </CustomModal>
   );
 };
 


### PR DESCRIPTION
## Description

Report creation missing data in tab pool certificate

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="314" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/1b5e9c09-317b-4b88-b045-ad8246b3aafb">


##### _After_

[comment]: <> (Add screenshots)
<img width="287" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9c0abd09-34e2-46bb-a249-a429ee7aae19">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)
<img width="179" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/cbfc08cb-4076-4785-9f99-a36187bb3356">


##### _After_

[comment]: <> (Add screenshots)
<img width="175" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/62da92cc-9171-4df6-ad17-0122f2972113">


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ