### PR TITLE
Bugfix/met 615 stake key registration not show full when hover delegated to test

### DIFF
--- a/src/components/commons/DetailView/DetailViewStakeKey.tsx
+++ b/src/components/commons/DetailView/DetailViewStakeKey.tsx
@@ -181,9 +181,7 @@ const DetailViewStakeKey: React.FC<DetailViewStakeKeyProps> = (props) => {
 
   const poolNameToolTip = data.pool?.poolName
     ? `${data.pool.tickerName || ""} - ${data.pool.poolName}`
-    : data.pool?.poolId
-    ? data.pool.poolId
-    : "-";
+    : data.pool?.poolId || "-";
 
   return (
     <ViewDetailDrawer anchor="right" open={!!stakeId} hideBackdrop variant="permanent">


### PR DESCRIPTION
## Description

Stake key registration not show full when hover delegation

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="465" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6e8da411-12f0-4b2a-9f36-416bae8a6b6c">


##### _After_

[comment]: <> (Add screenshots)
<img width="371" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/07d72450-6855-4ed8-a5ab-64a5a9b05d61">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ