### PR TITLE
fix: search block and epoch wrong

### DIFF
--- a/src/components/commons/Layout/Header/HeaderSearch/index.tsx
+++ b/src/components/commons/Layout/Header/HeaderSearch/index.tsx
@@ -127,7 +127,7 @@ const HeaderSearch: React.FC<Props> = ({ home, callback, setShowErrorMobile, his
 
   const handleSearch = async (e?: FormEvent, filterParams?: FilterParams) => {
     e?.preventDefault();
-    const option = options.find((item) => item.value === filter);
+    const option = options.find((item) => item.value === (filterParams || filter));
 
     if (option?.value === "lifecycle") {
       if (search.startsWith("stake")) {


### PR DESCRIPTION
## Description

currently search for a number and select block then the page is redirected to the epoch page

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)