### PR TITLE
Fix: MET-265 Finding 2 Fix Position saturation col in pool table

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -76,8 +76,8 @@ const DelegationLists: React.FC = () => {
       minWidth: "200px",
       key: "Saturation",
       render: (r) => (
-        <Box display="flex" alignItems="center" justifyContent={"space-between"}>
-          <Box component={"span"}>{formatPercent(r.saturation / 100) || `0%`}</Box>
+        <Box display="flex" alignItems="center" justifyContent={"end"}>
+          <Box component={"span"} mr={1}>{formatPercent(r.saturation / 100) || `0%`}</Box>
           <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : get(r, "saturation", 0)} />
         </Box>
       )

--- a/src/components/Home/TopDelegationPools/index.tsx
+++ b/src/components/Home/TopDelegationPools/index.tsx
@@ -61,8 +61,8 @@ const TopDelegationPools = () => {
       key: "Saturation",
       minWidth: "200px",
       render: (r) => (
-        <Box display="flex" alignItems="center" justifyContent={"space-between"}>
-          <Box component={"span"}>{formatPercent(r.saturation / 100) || `0%`}</Box>
+        <Box display="flex" alignItems="center" justifyContent={"end"}>
+          <Box component={"span"} mr={1}>{formatPercent(r.saturation / 100) || `0%`}</Box>
           <StyledLinearProgress variant="determinate" value={r.saturation > 100 ? 100 : get(r, "saturation", 0)} />
         </Box>
       )

--- a/src/components/Home/TopDelegationPools/style.ts
+++ b/src/components/Home/TopDelegationPools/style.ts
@@ -138,7 +138,7 @@ export const StyledProgress = styled("div")<{ value: number; width?: number }>`
 
 export const StyledLinearProgress = styled(LinearProgress)`
   display: inline-block;
-  width: 100%;
+  width: 150px;
   height: 8px;
   border-radius: 8px;
   background: ${(props) => alpha(props.theme.palette.common.black, 0.1)};


### PR DESCRIPTION
## Description

Fix position of element in saturation column in pool table

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-265](https://cardanofoundation.atlassian.net/browse/MET-265)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/58892fa7-3b65-4113-b239-4efe7105a58a)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/106212074/64f23659-3e49-4645-b1a0-457f080ae48f)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-265]: https://cardanofoundation.atlassian.net/browse/MET-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ