### PR TITLE
Bugfix/met 1415 finding 3 change text in card confirmation test

### DIFF
--- a/src/components/commons/DetailView/DetailViewBlock.tsx
+++ b/src/components/commons/DetailView/DetailViewBlock.tsx
@@ -200,9 +200,7 @@ const DetailViewBlock: React.FC<DetailViewBlockProps> = (props) => {
               <DetailValue>{formatDateTimeLocal(data.time || "")}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
-              <DetailLabel>
-                {data?.confirmation && data?.confirmation > 1 ? "Confirmations" : "Confirmation"}
-              </DetailLabel>
+              <DetailLabel>{data?.confirmation > 1 ? "Confirmations" : "Confirmation"}</DetailLabel>
               <DetailValue>{data?.confirmation}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>

--- a/src/components/commons/DetailView/DetailViewTransaction.tsx
+++ b/src/components/commons/DetailView/DetailViewTransaction.tsx
@@ -255,9 +255,7 @@ const DetailViewTransaction: React.FC<DetailViewTransactionProps> = (props) => {
               </DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
-              <DetailLabel>
-                {data?.tx?.confirmation && data?.tx?.confirmation > 1 ? "Confirmations" : "Confirmation"}
-              </DetailLabel>
+              <DetailLabel>{data?.tx?.confirmation > 1 ? "Confirmations" : "Confirmation"}</DetailLabel>
               <DetailValue>{data?.tx?.confirmation}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>


### PR DESCRIPTION
## Description

Change text in card confirmation
If value >1 => text change to Confirmations
If value < 1 => Text change to Confirmation

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="737" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ab4138cd-6ee9-4a12-a73a-54eac452f5fb">


##### _After_

[comment]: <> (Add screenshots)
<img width="509" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/b113a348-9693-403e-ac28-9fa0cdfa555b">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ