### PR TITLE
fix: MET-615-report-creation-show-full-when-hover

### DIFF
--- a/src/components/StakingLifeCycle/DelegatorLifecycle/ReportComposerModal/styles.ts
+++ b/src/components/StakingLifeCycle/DelegatorLifecycle/ReportComposerModal/styles.ts
@@ -205,7 +205,7 @@ export const TextValueReview = styled("div")`
   font-weight: 700;
   font-size: 16px;
   line-height: 19px;
-  max-width: 100%;
+  max-width: 250px;
   color: ${({ theme }) => theme.palette.common.black};
   ${({ theme }) => theme.breakpoints.down("sm")} {
     font-size: 14px;


### PR DESCRIPTION
## Description

Report creation show full when hover in text 

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="288" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/47f4671f-14aa-4cdb-ad34-0e239a42e5df">


##### _After_

[comment]: <> (Add screenshots)
<img width="350" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/f7aceec5-c045-4205-b623-718d64572175">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ