### PR TITLE
fix: MET-615-No-display-full-value-payment-wallet

### DIFF
--- a/src/components/TabularView/TabularOverview/index.tsx
+++ b/src/components/TabularView/TabularOverview/index.tsx
@@ -27,7 +27,8 @@ import {
   NoDelegatedStakePool,
   CardValueDelegating,
   BoxStyled,
-  StyledBoxDelegating
+  StyledBoxDelegating,
+  BoxValue
 } from "./styles";
 
 type TCardAmount = {
@@ -37,7 +38,9 @@ type TCardAmount = {
 const CardAmount = ({ amount }: TCardAmount) => {
   return (
     <CardValue>
-      {formatADAFull(amount)}
+      <CustomTooltip title={formatADAFull(amount)}>
+        <BoxValue>{formatADAFull(amount)}</BoxValue>
+      </CustomTooltip>
       <StyledAdaLogoIcon />
     </CardValue>
   );
@@ -74,7 +77,6 @@ const TabularOverview: React.FC = () => {
   const delegatingToValue =
     tickerName || poolName ? `${tickerName && tickerName + " -"}  ${poolName && poolName}` : getShortHash(poolId || "");
   const [open, setOpen] = useState(false);
-
   return (
     <Grid container spacing={2}>
       <Grid item xs={12} sm={6}>

--- a/src/components/TabularView/TabularOverview/styles.ts
+++ b/src/components/TabularView/TabularOverview/styles.ts
@@ -86,11 +86,11 @@ export const CardValue = styled(Typography)(({ theme }) => ({
   color: theme.palette.grey[700],
   whiteSpace: "nowrap",
   wordBreak: "break-all",
+  width: "100%",
+  display: "flex",
   [theme.breakpoints.down("sm")]: {
     fontSize: 20,
-    lineHeight: "23px",
-    whiteSpace: "wrap",
-    wordBreak: "break-all"
+    lineHeight: "23px"
   }
 }));
 export const CardValueDelegating = styled(CardValue)(() => ({
@@ -108,6 +108,14 @@ export const BoxStyled = styled(CardValue)(({ theme }) => ({
     whiteSpace: "nowrap"
   }
 }));
+export const BoxValue = styled(CardValue)(() => ({
+  display: "block",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  textAlign: "left",
+  width: "max-content"
+}));
+
 export const StyledBoxDelegating = styled(Link)(() => ({
   width: "100%",
   display: "flex",
@@ -123,6 +131,7 @@ export const NoDelegatedStakePool = styled(Box)(({ theme }) => ({
 export const StyledAdaLogoIcon = styled(AdaLogoIcon)(({ theme }) => ({
   fontSize: 18,
   marginLeft: 8,
+  paddingTop: 2,
   [theme.breakpoints.down("sm")]: {
     marginLeft: 5,
     fontSize: 16


### PR DESCRIPTION
## Description

No display full value payment wallet in Staking Delegation Lifecycle page at samsung galaxy fold ( opened ) screen

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/6570b1b5-f0cc-41be-8a60-842263644348)


##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/401bfd9d-c642-4635-b1ad-d0565aedb565)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ