### PR TITLE
Bugfix/met 1452 finding 1 2 token dropdown hex name displayed test

### DIFF
--- a/src/components/AddressDetail/AddressHeader/index.tsx
+++ b/src/components/AddressDetail/AddressHeader/index.tsx
@@ -137,7 +137,7 @@ const AddressHeader: React.FC<Props> = ({ data, loading }) => {
         <Grid item xs={12} md={6}>
           <StyledBoxCard>
             <CardAddress
-              title={"Stake Address"}
+              title={"Stake Key"}
               type="right"
               address={data?.stakeAddress || ""}
               item={itemRight}


### PR DESCRIPTION
## Description

- Remove  Token HEX name at the token dropdown associated to the addresses
- Add the token name HEX encoded version on the first card of the token details page underneath the token logo/name, and the field should be called “Hex Format: “

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1452](https://cardanofoundation.atlassian.net/browse/MET-1452)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/53935ae1-5af0-4189-ae3f-714b9bafa4dd)


![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a9ee461b-b3a7-4523-bbfa-96adecddfb59)


##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ebadd825-d2fd-47b9-96a4-88692fd038aa)

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/09bf7838-2438-4375-badf-095e645d7b62)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1452]: https://cardanofoundation.atlassian.net/browse/MET-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ