### PR TITLE
fix: MET-1443-finding-4-Change-design-in-collateral-tab

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+import { SxProps } from "@mui/system";
 import { Link } from "react-router-dom";
 
 import { useScreen } from "src/commons/hooks/useScreen";
@@ -11,22 +12,53 @@ import CopyButton from "src/components/commons/CopyButton";
 import CustomTooltip from "src/components/commons/CustomTooltip";
 import DropdownTokens from "src/components/commons/DropdownTokens";
 
-import { Header, Img, Item, ItemBox, ItemContent, Wrapper } from "./style";
+import { BoxHeaderBottom, BoxHeaderTop, Header, Img, Item, ItemBox, ItemContent, ItemFooter, Wrapper } from "./style";
 
 interface CollateralProps {
   data: Transaction["collaterals"] | null;
 }
 
 const Collaterals: React.FC<CollateralProps> = ({ data }) => {
+  const totalADAInput = (data?.collateralInputResponses || []).reduce((prv, item) => {
+    return prv + item.value;
+  }, 0);
+  const totalADAOutput = (data?.collateralOutputResponses || []).reduce((prv, item) => {
+    return prv + item.value;
+  }, 0);
+  const totalADA = totalADAInput - totalADAOutput;
+  const isShowCardInput = data?.collateralInputResponses && data?.collateralInputResponses.length > 0;
+  const isShowCardOutput = data?.collateralOutputResponses && data?.collateralOutputResponses.length > 0;
   return (
-    <Wrapper>
-      <Header>
-        <Box>Addresses</Box>
-        <Box>Amount</Box>
+    <Box>
+      {isShowCardInput && <Card type="input" items={data?.collateralInputResponses} />}
+      {isShowCardOutput && <Card type="output" items={data?.collateralOutputResponses} sx={{ mt: 1 }} />}
+      {isShowCardOutput && (
+        <ItemFooter>
+          <Box fontWeight={"bold"}>Total Output</Box>
+          <div>
+            <Box fontWeight={"bold"} component="span" pr={1}>
+              {formatADAFull(totalADA)}
+            </Box>
+            <ADAicon />
+          </div>
+        </ItemFooter>
+      )}
+    </Box>
+  );
+};
+
+const Card = ({ type, items, sx }: { type: "input" | "output"; items?: CollateralResponses[]; sx?: SxProps }) => {
+  return (
+    <Wrapper sx={sx}>
+      <Header fontWeight="bold">
+        <BoxHeaderTop>{type === "input" ? "Input" : "Output"}</BoxHeaderTop>
+        <BoxHeaderBottom>
+          <Box>Addresses</Box>
+          <Box>Amount</Box>
+        </BoxHeaderBottom>
       </Header>
       <ItemBox>
-        <ItemCollateral data={data?.collateralInputResponses || []} type="input" />
-        <ItemCollateral data={data?.collateralOutputResponses || []} type="output" />
+        <ItemCollateral data={items || []} type={type} />
       </ItemBox>
     </Wrapper>
   );
@@ -38,100 +70,102 @@ const ItemCollateral = ({ data, type }: { data: CollateralResponses[]; type: "in
   const { isTablet } = useScreen();
   return (
     <Box>
-      {data?.map((item) => (
-        <Item key={item.address}>
-          <ItemContent>
-            <Box display="flex" alignItems="center">
-              <Box width={50}>
-                <Img src={type === "input" ? receiveImg : sendImg} alt="send icon" />
-              </Box>
-              {isTablet ? <Box>{type === "input" ? "From" : "To"}:</Box> : null}
-            </Box>
-            <Box width={"100%"}>
-              <Box display={"flex"} justifyContent="space-between" alignItems={"center"}>
-                {!isTablet ? (
-                  <Box display={"flex"} alignItems="center" justifyContent={"flex-start"} pr={1} mr={1}>
-                    {type === "input" ? "From" : "To"}:
-                  </Box>
-                ) : null}
-                <Box display={"flex"} justifyContent="space-between" flex={"1"} alignItems={"center"}>
-                  <Box
-                    display={"flex"}
-                    justifyContent="flex-start"
-                    alignItems={"center"}
-                    flexWrap="nowrap"
-                    width={"auto"}
-                  >
-                    <Link to={details.address(item.address)}>
-                      <CustomTooltip title={item.address}>
-                        <Box
-                          color={(theme) => theme.palette.blue[800]}
-                          fontWeight="bold"
-                          fontFamily={"var(--font-family-text)"}
-                          mr={1}
-                        >
-                          {getShortWallet(item.address)}
-                        </Box>
-                      </CustomTooltip>
-                    </Link>{" "}
-                    <CopyButton text={item.address} />
-                  </Box>
-                  <Box
-                    display={"flex"}
-                    justifyContent="flex-start"
-                    alignItems={"center"}
-                    flexWrap="nowrap"
-                    width={"auto"}
-                  >
-                    <Box
-                      component={"span"}
-                      whiteSpace="nowrap"
-                      color={(theme) => (type === "output" ? theme.palette.primary.main : theme.palette.error.main)}
-                      fontWeight="bold"
-                      mr={1}
-                    >
-                      {type === "input" ? `-${formatADAFull(item.value)}` : `+${formatADAFull(item.value)}`}
-                    </Box>
-                    <ADAicon />
-                  </Box>
+      <Box>
+        {data?.map((item) => (
+          <Item key={item.address}>
+            <ItemContent>
+              <Box display="flex" alignItems="center">
+                <Box width={50}>
+                  <Img src={type === "input" ? receiveImg : sendImg} alt="send icon" />
                 </Box>
+                {isTablet ? <Box>{type === "input" ? "From" : "To"}:</Box> : null}
               </Box>
-              <Box justifyContent={"space-between"} alignItems={"flex-start"} width={"100%"} display="flex">
-                <Box mr={3}>
-                  {type === "input" && (
-                    <Box display={"flex"} justifyContent="flex-start" alignItems={"center"}>
-                      <Link to={details.transaction(item.txHash)}>
-                        <CustomTooltip title={item.txHash}>
+              <Box width={"100%"}>
+                <Box display={"flex"} justifyContent="space-between" alignItems={"center"}>
+                  {!isTablet ? (
+                    <Box display={"flex"} alignItems="center" justifyContent={"flex-start"} pr={1} mr={1}>
+                      {type === "input" ? "From" : "To"}:
+                    </Box>
+                  ) : null}
+                  <Box display={"flex"} justifyContent="space-between" flex={"1"} alignItems={"center"}>
+                    <Box
+                      display={"flex"}
+                      justifyContent="flex-start"
+                      alignItems={"center"}
+                      flexWrap="nowrap"
+                      width={"auto"}
+                    >
+                      <Link to={details.address(item.address)}>
+                        <CustomTooltip title={item.address}>
                           <Box
-                            component={"span"}
+                            color={(theme) => theme.palette.blue[800]}
                             fontWeight="bold"
                             fontFamily={"var(--font-family-text)"}
-                            color={(theme) => theme.palette.blue[800]}
                             mr={1}
                           >
-                            {getShortHash(item.txHash)}
+                            {getShortWallet(item.address)}
                           </Box>
                         </CustomTooltip>
-                      </Link>
-                      <CopyButton text={item.txHash} />
+                      </Link>{" "}
+                      <CopyButton text={item.address} />
+                    </Box>
+                    <Box
+                      display={"flex"}
+                      justifyContent="flex-start"
+                      alignItems={"center"}
+                      flexWrap="nowrap"
+                      width={"auto"}
+                    >
+                      <Box
+                        component={"span"}
+                        whiteSpace="nowrap"
+                        color={(theme) => (type === "output" ? theme.palette.primary.main : theme.palette.error.main)}
+                        fontWeight="bold"
+                        mr={1}
+                      >
+                        {type === "input" ? `-${formatADAFull(item.value)}` : `+${formatADAFull(item.value)}`}
+                      </Box>
+                      <ADAicon />
+                    </Box>
+                  </Box>
+                </Box>
+                <Box justifyContent={"space-between"} alignItems={"flex-start"} width={"100%"} display="flex">
+                  <Box mr={3}>
+                    {type === "input" && (
+                      <Box display={"flex"} justifyContent="flex-start" alignItems={"center"}>
+                        <Link to={details.transaction(item.txHash)}>
+                          <CustomTooltip title={item.txHash}>
+                            <Box
+                              component={"span"}
+                              fontWeight="bold"
+                              fontFamily={"var(--font-family-text)"}
+                              color={(theme) => theme.palette.blue[800]}
+                              mr={1}
+                            >
+                              {getShortHash(item.txHash)}
+                            </Box>
+                          </CustomTooltip>
+                        </Link>
+                        <CopyButton text={item.txHash} />
+                      </Box>
+                    )}
+                  </Box>
+                  {item.tokens && item.tokens.length > 1 && (
+                    <Box display={"flex"} alignItems={"center"}>
+                      <DropdownTokens
+                        tokens={item.tokens}
+                        type={type === "input" ? "up" : "down"}
+                        hideInputLabel
+                        hideMathChar
+                      />
                     </Box>
                   )}
                 </Box>
-                {item.tokens && item.tokens.length > 1 && (
-                  <Box display={"flex"} alignItems={"center"}>
-                    <DropdownTokens
-                      tokens={item.tokens}
-                      type={type === "input" ? "up" : "down"}
-                      hideInputLabel
-                      hideMathChar
-                    />
-                  </Box>
-                )}
               </Box>
-            </Box>
-          </ItemContent>
-        </Item>
-      ))}
+            </ItemContent>
+          </Item>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/src/components/TransactionDetail/TransactionMetadata/Collaterals/style.ts
+++ b/src/components/TransactionDetail/TransactionMetadata/Collaterals/style.ts
@@ -2,17 +2,8 @@ import { alpha, Box, styled } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const Wrapper = styled(Box)`
+  text-align: left;
   background: ${(props) => props.theme.palette.common.white};
-  padding: 25px;
-`;
-export const Header = styled(Box)`
-  display: flex;
-  justify-content: space-between;
-  font-size: var(--font-size-text-small);
-  font-weight: var(--font-weight-bold);
-  color: ${(props) => props.theme.palette.grey[500]};
-  border-bottom: 1px solid ${(props) => alpha(props.theme.palette.common.black, 0.1)};
-  padding-bottom: 8px;
 `;
 
 export const Img = styled("img")(() => ({
@@ -36,8 +27,15 @@ export const TokenLink = styled(Link)(({ theme }) => ({
 
 export const Item = styled(Box)(({ theme }) => ({
   textAlign: "left",
-  padding: "10px 0px",
-  borderBottom: `1px solid ${alpha(theme.palette.common.black, 0.1)}`
+  padding: "15px 0px 25px 0px !important",
+  margin: "0px 25px",
+  borderBottom: `1px solid ${alpha(theme.palette.common.black, 0.1)}`,
+  "&:last-of-type": {
+    borderBottom: "none"
+  },
+  [theme.breakpoints.down("sm")]: {
+    margin: "0 15px"
+  }
 }));
 export const ItemBox = styled(Box)(() => ({
   "> *:last-child > div": {
@@ -67,5 +65,39 @@ export const WrapToken = styled(Box)(({ theme }) => ({
       whiteSpace: "unset",
       margin: 0
     }
+  }
+}));
+
+export const Header = styled(Box)(({ theme }) => ({
+  padding: "8px 0 10px",
+  marginRight: "25px",
+  marginLeft: "25px",
+  fontSize: "12px",
+  color: theme.palette.text.primary,
+  borderBottom: `1px solid ${alpha(theme.palette.common.black, 0.1)}`,
+  [theme.breakpoints.down("sm")]: {
+    margin: "0 15px"
+  }
+}));
+export const BoxHeaderTop = styled(Box)(({ theme }) => ({
+  color: theme.palette.text.dark,
+  fontSize: "1rem",
+  lineHeight: "19px",
+  marginBottom: "2px"
+}));
+export const BoxHeaderBottom = styled(Box)(({ theme }) => ({
+  color: theme.palette.grey[500],
+  display: "flex",
+  justifyContent: "space-between"
+}));
+
+export const ItemFooter = styled(Box)(({ theme }) => ({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "12px 25px",
+  background: theme.palette.green[800_10],
+  [theme.breakpoints.down("sm")]: {
+    padding: "12px 15px"
   }
 }));


### PR DESCRIPTION
## Description

In the collateral tab, same as above point 3, we should copy the presentation layout of the UTXO tab, the input address/UTXO should be in the same format as the UXTO tab. Also there should be output field

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1443](https://cardanofoundation.atlassian.net/browse/MET-1443)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ae98f062-920e-4e6d-81b1-9d8cc8bad2ea)



##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/e6da1854-edce-4bc5-819b-50a46259b1dd)



#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1433]: https://cardanofoundation.atlassian.net/browse/MET-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1443]: https://cardanofoundation.atlassian.net/browse/MET-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ