### PR TITLE
Bugfix/met 1443 finding 4 change design in collateral tab test

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
@@ -19,7 +19,7 @@ interface CollateralProps {
 }
 
 const Collaterals: React.FC<CollateralProps> = ({ data }) => {
-  const totalADA = data?.collateralOutputResponses.reduce((prv, item) => {
+  const totalADA = (data?.collateralOutputResponses || []).reduce((prv, item) => {
     return prv + item.value;
   }, 0);
   const isShowCardInput = data?.collateralInputResponses && data?.collateralInputResponses.length > 0;


### PR DESCRIPTION
## Description

In the collateral tab, same as above point 3, we should copy the presentation layout of the UTXO tab, the input address/UTXO should be in the same format as the UXTO tab. Also there should be output field

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1443](https://cardanofoundation.atlassian.net/browse/MET-1443)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ae98f062-920e-4e6d-81b1-9d8cc8bad2ea)



##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5dd3012a-c784-4a76-9689-91b8df25fdbc)


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1433]: https://cardanofoundation.atlassian.net/browse/MET-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1443]: https://cardanofoundation.atlassian.net/browse/MET-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ