### PR TITLE
Bugfix/met 1443 finding 4 change design in collateral tab test

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Collaterals/index.tsx
@@ -53,7 +53,7 @@ const Card = ({ type, items, sx }: { type: "input" | "output"; items?: Collatera
       <Header fontWeight="bold">
         <BoxHeaderTop>{type === "input" ? "Input" : "Output"}</BoxHeaderTop>
         <BoxHeaderBottom>
-          <Box>Wallet Addresses</Box>
+          <Box>Addresses</Box>
           <Box>Amount</Box>
         </BoxHeaderBottom>
       </Header>
@@ -98,9 +98,9 @@ const ItemCollateral = ({ data, type }: { data: CollateralResponses[]; type: "in
                       <Link to={details.address(item.address)}>
                         <CustomTooltip title={item.address}>
                           <Box
+                            color={(theme) => theme.palette.blue[800]}
                             fontWeight="bold"
                             fontFamily={"var(--font-family-text)"}
-                            color={(theme) => theme.palette.blue[100]}
                             mr={1}
                           >
                             {getShortWallet(item.address)}


### PR DESCRIPTION
## Description

In the collateral tab, same as above point 3, we should copy the presentation layout of the UTXO tab, the input address/UTXO should be in the same format as the UXTO tab. Also there should be output field

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1443](https://cardanofoundation.atlassian.net/browse/MET-1443)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ae98f062-920e-4e6d-81b1-9d8cc8bad2ea)



##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/e6da1854-edce-4bc5-819b-50a46259b1dd)



#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-1433]: https://cardanofoundation.atlassian.net/browse/MET-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1443]: https://cardanofoundation.atlassian.net/browse/MET-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ