### PR TITLE
fix: MET-615-pool-list-can-not-sort-at-field-fixed-cost

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -122,7 +122,7 @@ const DelegationLists: React.FC = () => {
     },
     {
       title: "Fixed Cost (A)",
-      key: "fixedCost",
+      key: "pu.fixedCost",
       minWidth: "120px",
       render: (r) => `${formatADAFull(r.feeAmount)} A`,
       sort: ({ columnKey, sortValue }) => {


### PR DESCRIPTION
## Description

pool list can not sort at field fixed cost

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="369" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7ef6bb22-abb2-447b-8963-efc54366c68f">


##### _After_

[comment]: <> (Add screenshots)
<img width="374" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/740a5b54-0b26-4eb8-be1a-4c4aa96be7b4">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ