### PR TITLE
fix: MET-615-account-overview-hide-scroll-when-empty-data

### DIFF
--- a/src/components/commons/Table/index.tsx
+++ b/src/components/commons/Table/index.tsx
@@ -410,7 +410,7 @@ const Table: React.FC<TableProps> = ({
         maxHeight={maxHeight}
         minHeight={(!data || data.length === 0) && !loading ? 360 : loading ? 400 : 150}
         height={heightTable}
-        className={data && data.length !== 0 ? "table-wrapper" : ""}
+        className={data && data.length !== 0 ? "table-wrapper" : "hide-scroll"}
         loading={loading ? 1 : 0}
       >
         <TableFullWidth ref={tableRef}>

--- a/src/pages/Bookmark/Styles.ts
+++ b/src/pages/Bookmark/Styles.ts
@@ -18,6 +18,9 @@ export const StyledTable = styled(Table)(({ theme }) => ({
   "& .table-wrapper": {
     minHeight: "75px"
   },
+  "& .hide-scroll": {
+    overflow: "hidden"
+  },
   "thead tr th": {
     padding: "10px 25px",
     fontSize: "var(--font-size-text-x-small)"

--- a/src/pages/PrivateNotes/styles.ts
+++ b/src/pages/PrivateNotes/styles.ts
@@ -71,6 +71,9 @@ export const StyledTable = styled(Table)(({ theme }) => ({
   "& .table-wrapper": {
     minHeight: "75px"
   },
+  "& .hide-scroll": {
+    overflow: "hidden"
+  },
   "& thead tr th": {
     fontSize: "var(--font-size-text-x-small)",
     padding: "10px 20px"


### PR DESCRIPTION
## Description

account overview page need to hide scroll when empty data at table

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="454" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3b007c9e-2783-4695-884e-75979948c96d">


##### _After_

[comment]: <> (Add screenshots)
<img width="444" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/48d594ca-539c-4249-b234-7b23db6effec">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ