### PR TITLE
fix: MET-615-stake-address-detail-remove-space-at-bottom-page

### DIFF
--- a/src/pages/StakeDetail/styles.ts
+++ b/src/pages/StakeDetail/styles.ts
@@ -1,7 +1,7 @@
 import { styled, Container } from "@mui/material";
 
 export const StyledContainer = styled(Container)`
-  padding: 30px 16px 40px;
+  padding: 30px 16px 0px;
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
## Description

stake address detail remove space at bottom page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="729" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/58c704ef-8584-4c54-91cd-8d3d5c5c8c43">


##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)
<img width="635" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/971091f5-d9e9-4297-ab79-fdb15b8c5697">




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ