### PR TITLE
fix: 1271 add field unique account reward accounts

### DIFF
--- a/src/components/EpochDetail/EpochOverview/index.tsx
+++ b/src/components/EpochDetail/EpochOverview/index.tsx
@@ -9,7 +9,8 @@ import {
   cubeIconUrl,
   slotIconUrl,
   exchageIconUrl,
-  RewardIcon
+  RewardIcon,
+  User2
 } from "src/commons/resources";
 import { MAX_SLOT_EPOCH } from "src/commons/utils/constants";
 import DetailHeader from "src/components/commons/DetailHeader";
@@ -83,6 +84,15 @@ const EpochOverview: React.FC<EpochOverviewProps> = ({ data, loading, lastUpdate
           <Subtext>/{MAX_SLOT_EPOCH}</Subtext>
         </>
       )
+    },
+    {
+      icon: User2,
+      title: (
+        <Box display={"flex"} alignItems="center">
+          <TitleCard mr={1}> Unique Accounts</TitleCard>
+        </Box>
+      ),
+      value: data?.account
     },
     {
       icon: exchageIconUrl,

--- a/src/components/commons/DetailView/DetailViewEpoch.tsx
+++ b/src/components/commons/DetailView/DetailViewEpoch.tsx
@@ -3,6 +3,7 @@ import { CgClose } from "react-icons/cg";
 import { BiChevronRight } from "react-icons/bi";
 import { useSelector } from "react-redux";
 import moment from "moment";
+import { Box } from "@mui/material";
 
 import { MAX_SLOT_EPOCH, REFRESH_TIMES } from "src/commons/utils/constants";
 import { BlockIcon, CubeIcon, RocketIcon } from "src/commons/resources";
@@ -214,8 +215,25 @@ const DetailViewEpoch: React.FC<DetailViewEpochProps> = ({ epochNo, handleClose,
               <DetailValue>{data.blkCount}</DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
+              <DetailLabel>Unique Accounts</DetailLabel>
+              <DetailValue>{data.account}</DetailValue>
+            </DetailsInfoItem>
+            <DetailsInfoItem>
               <DetailLabel>Tx Count</DetailLabel>
               <DetailValue>{data.txCount}</DetailValue>
+            </DetailsInfoItem>
+            <DetailsInfoItem>
+              <DetailLabel>Rewards Distributed</DetailLabel>
+              <DetailValue>
+                {data?.rewardsDistributed ? (
+                  <Box>
+                    {formatADAFull(data?.rewardsDistributed)}
+                    <ADAicon />
+                  </Box>
+                ) : (
+                  "Not available"
+                )}
+              </DetailValue>
             </DetailsInfoItem>
             <DetailsInfoItem>
               <DetailLabel>Total Output</DetailLabel>


### PR DESCRIPTION
## Description

fix: MET-1271 add field unique account, reward account in deatil view and epoch detail
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [MET-1271](https://cardanofoundation.atlassian.net/browse/MET-1271)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
Before:
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/16cc3da9-803a-4921-9619-57fae748f522)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/57de94fb-873d-429a-b5c1-4e6c58a84ead)

After:

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/abf156cd-615c-48d7-8827-4ff0cb21537f)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/0e9af615-1981-4914-a016-21bc5d4c7cb7)



[MET-1271]: https://cardanofoundation.atlassian.net/browse/MET-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ