### PR TITLE
Fix: MET-1292 Finding 1 able to click the whole card to redirect on statistic homepage

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -22,6 +22,7 @@ import {
   Item,
   ItemIcon,
   ItemSkeleton,
+  Link,
   Name,
   ProcessActive,
   Progress,
@@ -79,162 +80,170 @@ const HomeStatistic = () => {
     >
       <Grid sx={{ display: "flex", flexDirection: "column" }} item xl lg={3} sm={6} xs={6}>
         {usdMarket && btcMarket?.[0] ? (
-          <Item data-testid="ada-price-box" onClick={() => window.open(EXT_ADA_PRICE_URL, "_blank")}>
-            <ItemIcon
-              style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
-              data-testid="ada-price-icon"
-              src={AdaPriceIcon}
-              alt="Ada Price"
-            />
-            <Content>
-              <Name data-testid="ada-price-box-title">Ada Price</Name>
-              <Title data-testid="ada-current-price">${usdMarket.current_price}</Title>
-              <br />
-              <RateWithIcon
-                data-testid="ada-twenty-four-hr-price-change"
-                value={usdMarket.price_change_percentage_24h}
+          <Link href={EXT_ADA_PRICE_URL} target="_blank">
+            <Item data-testid="ada-price-box">
+              <ItemIcon
+                style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
+                data-testid="ada-price-icon"
+                src={AdaPriceIcon}
+                alt="Ada Price"
               />
-              <AdaPrice data-testid="ada-price-in-btc">{btcMarket[0]?.current_price} BTC</AdaPrice>
-              <TimeDuration marginTop="8px" data-testid="last-update-btc">
-                Last updated {moment(btcMarket[0]?.last_updated).fromNow()}
-              </TimeDuration>
-            </Content>
-          </Item>
+              <Content>
+                <Name data-testid="ada-price-box-title">Ada Price</Name>
+                <Title data-testid="ada-current-price">${usdMarket.current_price}</Title>
+                <br />
+                <RateWithIcon
+                  data-testid="ada-twenty-four-hr-price-change"
+                  value={usdMarket.price_change_percentage_24h}
+                />
+                <AdaPrice data-testid="ada-price-in-btc">{btcMarket[0]?.current_price} BTC</AdaPrice>
+                <TimeDuration marginTop="8px" data-testid="last-update-btc">
+                  Last updated {moment(btcMarket[0]?.last_updated).fromNow()}
+                </TimeDuration>
+              </Content>
+            </Item>
+          </Link>
         ) : (
           <SkeletonBox />
         )}
       </Grid>
       <Grid sx={{ display: "flex", flexDirection: "column" }} item xl lg={3} sm={6} xs={6}>
         {usdMarket ? (
-          <Item data-testid="market-cap-box" onClick={() => window.open(EXT_ADA_PRICE_URL, "_blank")}>
-            <ItemIcon
-              style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
-              data-testid="market-cap-icon"
-              src={MarketCapIcon}
-              alt="Market cap"
-            />
-            <Content>
-              <Name data-testid="market-cap-box-title">Market cap</Name>
-              <Title data-testid="market-cap-value">${numberWithCommas(usdMarket.market_cap)}</Title>
-              <TimeDuration data-testid="last-update-market-cap">
-                Last updated {moment(usdMarket.last_updated).fromNow()}
-              </TimeDuration>
-            </Content>
-          </Item>
+          <Link href={EXT_ADA_PRICE_URL} target="_blank">
+            <Item data-testid="market-cap-box">
+              <ItemIcon
+                style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
+                data-testid="market-cap-icon"
+                src={MarketCapIcon}
+                alt="Market cap"
+              />
+              <Content>
+                <Name data-testid="market-cap-box-title">Market cap</Name>
+                <Title data-testid="market-cap-value">${numberWithCommas(usdMarket.market_cap)}</Title>
+                <TimeDuration data-testid="last-update-market-cap">
+                  Last updated {moment(usdMarket.last_updated).fromNow()}
+                </TimeDuration>
+              </Content>
+            </Item>
+          </Link>
         ) : (
           <SkeletonBox />
         )}
       </Grid>
       <Grid sx={{ display: "flex", flexDirection: "column" }} item xl lg={3} sm={6} xs={6}>
         {currentEpoch ? (
-          <Item data-testid="current-epoch-box" onClick={() => window.open(details.epoch(currentEpoch?.no))}>
-            <Content>
-              <Box display={"flex"} alignItems="center" position={"absolute"} right={10} top={15}>
-                <ProgressCircle
-                  size={50}
-                  pathLineCap="butt"
-                  pathWidth={6}
-                  trailWidth={6}
-                  percent={Number(progress)}
-                  trailOpacity={1}
-                >
-                  <EpochProgress sx={{ fontSize: "15px" }}>{`${progress}%`}</EpochProgress>
-                </ProgressCircle>
-              </Box>
-              <Name data-testid="current-epoch-box-title" style={isGalaxyFoldSmall ? { maxWidth: "30px" } : {}}>
-                Current Epoch
-              </Name>
-              <XSmall data-testid="epoch-label">Epoch: </XSmall>
-              {isMobile ? <br /> : null}
-              <XValue data-testid="current-epoch-number">
-                <b>{numberWithCommas(currentEpoch?.no)}</b>
-              </XValue>
-              <br />
-              <XSmall data-testid="slot-label">Slot: </XSmall>
-              {isMobile ? <br /> : null}
-              <XValue data-testid="current-slot-number">
-                <b>{numberWithCommas(currentEpoch?.slot % MAX_SLOT_EPOCH)}</b>
-              </XValue>
-              <XSmall> / {numberWithCommas(MAX_SLOT_EPOCH)}</XSmall>
-              <br />
-              <XSmall>Unique accounts: </XSmall>
-              {isMobile ? <br /> : null}
-              <XValue>
-                <b data-testid="curent-epoch-account">{numberWithCommas(currentEpoch?.account)}</b>
-              </XValue>
-              <br />
-              <XSmall>End timestamp: </XSmall>
-              {isMobile ? <br /> : null}
-              <XValue>
-                <b
-                  style={{
-                    whiteSpace: isGalaxyFoldSmall ? "normal" : "nowrap"
-                  }}
-                >
-                  {formatDateTimeLocal(currentEpoch?.endTime)}
-                </b>
-              </XValue>
-            </Content>
-          </Item>
+          <Link href={details.epoch(currentEpoch?.no)} target="_blank">
+            <Item data-testid="current-epoch-box">
+              <Content>
+                <Box display={"flex"} alignItems="center" position={"absolute"} right={10} top={15}>
+                  <ProgressCircle
+                    size={50}
+                    pathLineCap="butt"
+                    pathWidth={6}
+                    trailWidth={6}
+                    percent={Number(progress)}
+                    trailOpacity={1}
+                  >
+                    <EpochProgress sx={{ fontSize: "15px" }}>{`${progress}%`}</EpochProgress>
+                  </ProgressCircle>
+                </Box>
+                <Name data-testid="current-epoch-box-title" style={isGalaxyFoldSmall ? { maxWidth: "30px" } : {}}>
+                  Current Epoch
+                </Name>
+                <XSmall data-testid="epoch-label">Epoch: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue data-testid="current-epoch-number">
+                  <b>{numberWithCommas(currentEpoch?.no)}</b>
+                </XValue>
+                <br />
+                <XSmall data-testid="slot-label">Slot: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue data-testid="current-slot-number">
+                  <b>{numberWithCommas(currentEpoch?.slot % MAX_SLOT_EPOCH)}</b>
+                </XValue>
+                <XSmall> / {numberWithCommas(MAX_SLOT_EPOCH)}</XSmall>
+                <br />
+                <XSmall>Unique accounts: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue>
+                  <b data-testid="curent-epoch-account">{numberWithCommas(currentEpoch?.account)}</b>
+                </XValue>
+                <br />
+                <XSmall>End timestamp: </XSmall>
+                {isMobile ? <br /> : null}
+                <XValue>
+                  <b
+                    style={{
+                      whiteSpace: isGalaxyFoldSmall ? "normal" : "nowrap"
+                    }}
+                  >
+                    {formatDateTimeLocal(currentEpoch?.endTime)}
+                  </b>
+                </XValue>
+              </Content>
+            </Item>
+          </Link>
         ) : (
           <SkeletonBox />
         )}
       </Grid>
       <Grid sx={{ display: "flex", flexDirection: "column" }} item xl lg={3} sm={6} xs={6}>
         {data && usdMarket ? (
-          <Item data-testid="live-stake-box" onClick={() => window.open(routers.DELEGATION_POOLS)}>
-            <Content>
-              <ItemIcon
-                style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
-                data-testid="live-stake-icon"
-                src={LiveStakeIcon}
-                alt="Total ADA Stake"
-              />
-              <Name data-testid="live-stake-box-title">Live Stake (ADA)</Name>
-              <CustomTooltip title={formatADAFull(liveStake)}>
-                <Title data-testid="live-stake-value">{formatADA(liveStake)}</Title>
-              </CustomTooltip>
-              <Progress>
-                <CustomTooltip title={liveRate.toFixed(5)}>
-                  <ProcessActive data-testid="live-stake-progress-active" rate={liveRate.toNumber()}>
-                    {liveRate.toFixed(0, BigNumber.ROUND_DOWN)}%
-                  </ProcessActive>
+          <Link href={routers.DELEGATION_POOLS} target="_blank">
+            <Item data-testid="live-stake-box">
+              <Content>
+                <ItemIcon
+                  style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
+                  data-testid="live-stake-icon"
+                  src={LiveStakeIcon}
+                  alt="Total ADA Stake"
+                />
+                <Name data-testid="live-stake-box-title">Live Stake (ADA)</Name>
+                <CustomTooltip title={formatADAFull(liveStake)}>
+                  <Title data-testid="live-stake-value">{formatADA(liveStake)}</Title>
                 </CustomTooltip>
-                <CustomTooltip title={liveRate.div(-1).plus(100).toFixed(5)}>
-                  <ProgressPending
-                    data-testid="live-stake-progress-pending"
-                    rate={liveRate.div(-1).plus(100).toNumber()}
-                  >
-                    {liveRate.div(-1).plus(100).toFixed(0)}%
-                  </ProgressPending>
-                </CustomTooltip>
-              </Progress>
-              <XSmall data-testid="active-stake-label">Active Stake (ADA): </XSmall>
-              {isMobile ? <br /> : null}
-              <SmallValue>
-                <CustomTooltip title={formatADAFull(activeStake)}>
-                  <XValue data-testid="active-stake-value">
-                    <b>{formatADA(activeStake)} </b>
-                  </XValue>
-                </CustomTooltip>
-              </SmallValue>
-              <br />
-              <XSmall data-testid="circulating-supply-label">Circulating supply (ADA): </XSmall>
-              {isMobile ? <br /> : null}
-              <SmallValue>
-                <XValue data-testid="circulating-supply-value">
-                  <CustomTooltip title={numberWithCommas(supply)}>
-                    <b>{formatADA(circulatingSupply.toString())} </b>
+                <Progress>
+                  <CustomTooltip title={liveRate.toFixed(5)}>
+                    <ProcessActive data-testid="live-stake-progress-active" rate={liveRate.toNumber()}>
+                      {liveRate.toFixed(0, BigNumber.ROUND_DOWN)}%
+                    </ProcessActive>
                   </CustomTooltip>
-                </XValue>
-                <CustomTooltip title={`${circulatingRate.toFixed(5)}%`}>
-                  <Small data-testid="circulating-supply-percentage">
-                    ({circulatingRate.toFixed(0, BigNumber.ROUND_DOWN)}%)
-                  </Small>
-                </CustomTooltip>
-              </SmallValue>
-            </Content>
-          </Item>
+                  <CustomTooltip title={liveRate.div(-1).plus(100).toFixed(5)}>
+                    <ProgressPending
+                      data-testid="live-stake-progress-pending"
+                      rate={liveRate.div(-1).plus(100).toNumber()}
+                    >
+                      {liveRate.div(-1).plus(100).toFixed(0)}%
+                    </ProgressPending>
+                  </CustomTooltip>
+                </Progress>
+                <XSmall data-testid="active-stake-label">Active Stake (ADA): </XSmall>
+                {isMobile ? <br /> : null}
+                <SmallValue>
+                  <CustomTooltip title={formatADAFull(activeStake)}>
+                    <XValue data-testid="active-stake-value">
+                      <b>{formatADA(activeStake)} </b>
+                    </XValue>
+                  </CustomTooltip>
+                </SmallValue>
+                <br />
+                <XSmall data-testid="circulating-supply-label">Circulating supply (ADA): </XSmall>
+                {isMobile ? <br /> : null}
+                <SmallValue>
+                  <XValue data-testid="circulating-supply-value">
+                    <CustomTooltip title={numberWithCommas(supply)}>
+                      <b>{formatADA(circulatingSupply.toString())} </b>
+                    </CustomTooltip>
+                  </XValue>
+                  <CustomTooltip title={`${circulatingRate.toFixed(5)}%`}>
+                    <Small data-testid="circulating-supply-percentage">
+                      ({circulatingRate.toFixed(0, BigNumber.ROUND_DOWN)}%)
+                    </Small>
+                  </CustomTooltip>
+                </SmallValue>
+              </Content>
+            </Item>
+          </Link>
         ) : (
           <SkeletonBox />
         )}

--- a/src/components/Home/Statistic/style.ts
+++ b/src/components/Home/Statistic/style.ts
@@ -145,3 +145,7 @@ export const ProgressPending = styled(ProcessActive)<{ rate: number }>`
   width: ${(props) => props.rate}%;
   background-color: ${(props) => props.theme.palette.warning.main};
 `;
+
+export const Link = styled("a")`
+  display: contents;
+`;


### PR DESCRIPTION

## Description

Fix can't click the whole card to redirect on statistic homepage.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1292](https://cardanofoundation.atlassian.net/browse/MET-1292)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1292]: https://cardanofoundation.atlassian.net/browse/MET-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ