### PR TITLE
fix: MET-1249 stake analytics chart y axis mobile

### DIFF
--- a/src/components/StakeDetail/StakeAnalytics/index.tsx
+++ b/src/components/StakeDetail/StakeAnalytics/index.tsx
@@ -168,7 +168,7 @@ const StakeAnalytics: React.FC = () => {
                     tickLine={false}
                     {...xAxisProps}
                   />
-                  <YAxis tickFormatter={formatPriceValue} tickLine={false} interval={isMobile ? 3 : undefined} />
+                  <YAxis tickFormatter={formatPriceValue} tickLine={false} />
                   <Tooltip content={renderTooltip} cursor={false} />
                   <CartesianGrid vertical={false} strokeWidth={0.33} />
                   <Area


### PR DESCRIPTION
## Description

[MET-1249] Fix bug stake analytics chart y axis show only point in mobile

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1249](https://cardanofoundation.atlassian.net/browse/MET-1249)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

No change

#### Safari

No change

#### Responsive

| Before | After |
|--------|--------|
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/13be5196-84d0-4833-83c9-70775a580f91) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/982cd98a-3a79-42c7-8281-45d9601536e6)|

[MET-1249]: https://cardanofoundation.atlassian.net/browse/MET-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MET-1249]: https://cardanofoundation.atlassian.net/browse/MET-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ