### PR TITLE
Bugfix/met 1253 finding 1 epoch ending time displaying incorrect time

### DIFF
--- a/src/components/DelegationPool/DelegationOverview/index.tsx
+++ b/src/components/DelegationPool/DelegationOverview/index.tsx
@@ -51,9 +51,8 @@ const OverViews: React.FC = () => {
       </Grid>
     );
   }
-  const slot = currentEpoch?.slot || 0;
+  const slot = (currentEpoch?.slot || 0) % MAX_SLOT_EPOCH;
   const countdown = MAX_SLOT_EPOCH - slot;
-
   const duration = moment.duration(countdown ? countdown : 0, "second");
   const days = duration.days();
   const hours = duration.hours();


### PR DESCRIPTION
## Description

Epoch ending time displaying incorrect time

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1253](https://cardanofoundation.atlassian.net/browse/MET-1253)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="149" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7ffe1f95-05ad-4bdf-a065-a88504e93cba">


##### _After_

[comment]: <> (Add screenshots)
<img width="146" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/47f625fe-3076-478f-b685-b8b8c32e420a">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-1253]: https://cardanofoundation.atlassian.net/browse/MET-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ