### PR TITLE
fix: MET-615-address-detail-no-name-is-display-blank

### DIFF
--- a/src/commons/utils/helper.ts
+++ b/src/commons/utils/helper.ts
@@ -13,11 +13,11 @@ export const alphaNumeric = /[^0-9a-zA-Z]/;
 export const regexEmail = /^[\w\.\+\-]+@([\w-]+\.)+[\w-]{2,4}$/;
 
 export const getShortWallet = (address = "") => {
-  return `${address.slice(0, 5)}...${address.slice(-5)}`;
+  return address ? `${address.slice(0, 5)}...${address.slice(-5)}` : "";
 };
 
 export const getShortHash = (address = "") => {
-  return `${address.slice(0, 10)}...${address.slice(-7)}`;
+  return address ? `${address.slice(0, 10)}...${address.slice(-7)}` : "";
 };
 
 export const LARGE_NUMBER_ABBREVIATIONS = ["", "K", "M", "B", "T", "q", "Q", "s", "S"];


### PR DESCRIPTION
## Description

Address detail no name is display blank in card address header

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="575" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/0ac107f3-96a3-4d8c-8a2a-73abf64c6adc">


##### _After_

[comment]: <> (Add screenshots)
<img width="491" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/ff3434ad-9598-4c3a-8e8d-3991c570f6db">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ