### PR TITLE
fix: MET-615-contract-detail-replace-dot-to-text-not-delegated-to-any…

### DIFF
--- a/src/components/ContractDetail/AddressOverview/index.tsx
+++ b/src/components/ContractDetail/AddressOverview/index.tsx
@@ -78,23 +78,20 @@ const AddressOverview: React.FC<Props> = ({ data, loading }) => {
     },
     {
       title: "Delegated To",
-      value: (
-        <span>
-          {dataStake?.pool?.poolName || dataStake?.pool?.poolId ? (
-            <Pool to={details.delegation(dataStake?.pool ? dataStake?.pool?.poolId : "")}>
-              {dataStake?.pool?.poolName ? (
-                dataStake?.pool?.poolName
-              ) : (
-                <CustomTooltip title={dataStake?.pool?.poolId || ""} arrow>
-                  <span>{getShortWallet(dataStake?.pool?.poolId || "")}</span>
-                </CustomTooltip>
-              )}
-            </Pool>
-          ) : (
-            "Not delegated to any pool"
-          )}
-        </span>
-      )
+      value:
+        dataStake?.pool?.poolName || dataStake?.pool?.poolId ? (
+          <Pool to={details.delegation(dataStake?.pool ? dataStake?.pool?.poolId : "")}>
+            {dataStake?.pool?.poolName ? (
+              dataStake?.pool?.poolName
+            ) : (
+              <CustomTooltip title={dataStake?.pool?.poolId || ""} arrow>
+                <span>{getShortWallet(dataStake?.pool?.poolId || "")}</span>
+              </CustomTooltip>
+            )}
+          </Pool>
+        ) : (
+          <span>Not delegated to any pool</span>
+        )
     }
   ];
 


### PR DESCRIPTION
## Description

Contract detail replace dot to text not delegated to any

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

<img width="541" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/0392e611-a83e-41a5-acaa-cb507a5ff68a">


##### _After_

[comment]: <> (Add screenshots)
<img width="461" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/31831b01-11ec-46dd-9309-6b9aadad5f78">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ