### PR TITLE
fix: MET-615-bookmark-wrong-default-per-page

### DIFF
--- a/src/pages/Bookmark/index.tsx
+++ b/src/pages/Bookmark/index.tsx
@@ -68,7 +68,7 @@ const Bookmark = () => {
   const handleChange = (event: React.SyntheticEvent, tab: Bookmark["type"]) => {
     setActiveTab(tab);
     setPage(0);
-    setSize(10);
+    setSize(50);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description

bookmark wrong default per page, page default is 50 instead of 10

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="722" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3007bb3f-a52d-4467-b668-101de8c8b835">


##### _After_

[comment]: <> (Add screenshots)

<img width="602" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/84e53e70-6070-4537-9c9c-ffbb7a975651">



#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ