### PR TITLE
fix: MET-1420 finding 1 add Epoch text to reward chart in stake analytics

### DIFF
--- a/src/components/StakeDetail/StakeAnalytics/index.tsx
+++ b/src/components/StakeDetail/StakeAnalytics/index.tsx
@@ -93,7 +93,7 @@ const StakeAnalytics: React.FC = () => {
         <TooltipLabel>
           {tab === "BALANCE"
             ? moment(content.label).format("DD MMM YYYY HH:mm:ss") + " (UTC time zone)"
-            : content.label}
+            : `Epoch ${content.label}`}
         </TooltipLabel>
         <TooltipValue>{formatADAFull(content.payload?.[0]?.value) || 0}</TooltipValue>
       </TooltipBody>


### PR DESCRIPTION
## Description

fix: MET-1420 finding 1 add Epoch text to reward chart in stake analytics

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1420](https://cardanofoundation.atlassian.net/browse/MET-1420)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|---------|
| ![Screenshot_35](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/3aa0207c-24db-4d7d-960c-916fdf215985) | ![Screenshot_34](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/ca19269c-6758-43a5-a312-aa1bfa9e6801) |

#### Safari

Same Chrome

#### Responsive

| Before | After |
|--------|---------|
| ![Screenshot_36](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/d748dfe1-32a0-46bb-9c3d-bff5835a9509) | ![Screenshot_37](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/47d2a23d-1bbd-4568-af57-5b5f10a78997) |

[MET-1420]: https://cardanofoundation.atlassian.net/browse/MET-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ