### PR TITLE
fix: MET-615-lifecycle-trim-space-input-value-in-search-input

### DIFF
--- a/src/pages/StakingLifeCycleSearch/index.tsx
+++ b/src/pages/StakingLifeCycleSearch/index.tsx
@@ -40,7 +40,7 @@ const StakingLifeCycleSearch = () => {
           <StyledInput
             placeholder="Type a stake address or pool id"
             onChange={(e) => {
-              setValue(e.target.value);
+              setValue(e.target.value.trim());
               setError("");
             }}
             value={value}


### PR DESCRIPTION
## Description

Delegator lifecycle and Spo lifecycle page, when user input value in search input, we need to remove space at both side of input value, it will prevent return no data.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="538" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/8ce32bee-0755-4484-9aba-682c9df40a4a">


##### _After_

[comment]: <> (Add screenshots)

<img width="525" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/a318a050-31a2-4d74-a18d-d809a74fee8a">

#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ