### PR TITLE
fix: MET-615-Set-max-width-for-containermui-to-95vw---missing-code-wh…

### DIFF
--- a/src/pages/Stake/styles.ts
+++ b/src/pages/Stake/styles.ts
@@ -2,6 +2,7 @@ import { styled, Container, Tabs, Tab } from "@mui/material";
 import { Link } from "react-router-dom";
 
 export const StyledContainer = styled(Container)(({ theme }) => ({
+  maxWidth: "95vw !important",
   paddingTop: "30px",
   textAlign: "left",
   [theme.breakpoints.down("md")]: {


### PR DESCRIPTION

## Description

Set max width for container MUI to 95vw at Registration stake page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="818" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/df15a234-ddbb-441d-9f4b-f24030e02828">


##### _After_

[comment]: <> (Add screenshots)
<img width="820" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/7ecf58b1-4612-4171-bc4c-53518de602db">


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)


[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ