### PR TITLE
fix: MET-1452 finding 1 view only tokens in dropdown search

### DIFF
--- a/src/components/TokenAutocomplete/index.tsx
+++ b/src/components/TokenAutocomplete/index.tsx
@@ -28,7 +28,6 @@ import CustomModal from "../commons/CustomModal";
 
 const TokenAutocomplete = ({ address }: { address: string }) => {
   const [openModalToken, setOpenModalToken] = useState(false);
-  const [selected, setSelected] = useState("");
   const [search, setSearch] = useState("");
   const urlFetch = `${API.ADDRESS.TOKENS}?displayName=${search}`.replace(":address", address);
   const { data, loading, total } = useFetchList<WalletAddress["tokens"][number]>(address && urlFetch, {
@@ -47,7 +46,6 @@ const TokenAutocomplete = ({ address }: { address: string }) => {
           typeof option === "string" ? "more" : option.displayName || option.name || option.fingerprint
         }
         onInputChange={debounce((e, value) => setSearch(value), 500)}
-        onChange={(e, value) => typeof value !== "string" && setSelected(value?.fingerprint || "")}
         ListboxProps={{
           sx(theme) {
             return {
@@ -74,7 +72,7 @@ const TokenAutocomplete = ({ address }: { address: string }) => {
         renderOption={(propss, option: WalletAddress["tokens"][number] | string) => {
           if (typeof option === "string") {
             return (
-              <Option key={"more"} {...propss} onClick={() => null} active={0}>
+              <Option key={"more"} {...propss} onClick={() => null}>
                 <Box
                   display="flex"
                   alignItems={"center"}
@@ -100,7 +98,7 @@ const TokenAutocomplete = ({ address }: { address: string }) => {
             );
           }
           return (
-            <Option key={option.fingerprint} {...propss} active={selected === option.fingerprint ? 1 : 0}>
+            <Option key={option.fingerprint} {...propss} onClick={() => null}>
               <Box
                 display="flex"
                 alignItems={"center"}

--- a/src/components/TokenAutocomplete/styles.ts
+++ b/src/components/TokenAutocomplete/styles.ts
@@ -69,8 +69,8 @@ export const StyledTextField = styled(TextField)`
   }
 `;
 
-export const Option = styled("li")<{ active: number }>(({ theme, active }) => ({
-  background: active ? theme.palette.primary[200] : theme.palette.secondary[0]
+export const Option = styled("li")(({ theme }) => ({
+  background: theme.palette.secondary[0]
 }));
 
 export const Logo = styled("img")`


### PR DESCRIPTION
## Description

fix: MET-1452 finding 1 view only tokens in dropdown search

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1452](https://cardanofoundation.atlassian.net/browse/MET-1452)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
Before
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/1cad6ac7-a40f-41ab-8e09-7c0fcf02ba88)
After
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/c5e7bbcd-0d2b-4ccc-b4fa-1cb65a9ddd60)


[MET-1452]: https://cardanofoundation.atlassian.net/browse/MET-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ