### PR TITLE
fix: tabular view display pool name tooltip wrong position

### DIFF
--- a/src/components/TabularView/TabularOverview/styles.ts
+++ b/src/components/TabularView/TabularOverview/styles.ts
@@ -117,7 +117,8 @@ export const BoxValue = styled(CardValue)(() => ({
 }));
 
 export const StyledBoxDelegating = styled(Link)(() => ({
-  width: "100%",
+  width:"max-content",
+  maxWidth: "100%",
   display: "flex",
   justifyContent: "flex-start",
   alignItems: "center"


### PR DESCRIPTION
## Description

Fix: tabular view display pool name tooltip wrong position.
Expect: tooltip is center of text.
Actual: tooltip is right of text.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No ticket jira

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|--------|
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/049aaa51-2204-4781-a0f6-227f432b1ded) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/367f1699-8cc1-4d6a-b919-532867f5782e) |

#### Safari

Same chrome

#### Responsive

Tablet

| Before | After |
|--------|--------|
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/08c0d702-c98f-4310-991f-a386ca5232a9) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/af0f9c3c-ab2f-45f6-8770-cdff5835ab94) |

Mobile

| Before | After |
|--------|--------|
| ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/0abebb9f-e3d4-4e19-85e1-719a1df59d7a) | ![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/2005988e-cc30-4a69-be70-b893af84061e) |