### PR TITLE
fix: report-detail-text-deregistration-wrong( MET-1394 )

### DIFF
--- a/src/components/ReportGeneratedPoolDetail/index.tsx
+++ b/src/components/ReportGeneratedPoolDetail/index.tsx
@@ -51,7 +51,7 @@ const poolTabs: ITab[] = [
   },
   {
     icon: DeredistrationIcon,
-    label: "Deregsitration",
+    label: "Deregistration",
     key: "deregistration",
     mappingKey: "deregistration",
     component: <DeregsitrationTab />


### PR DESCRIPTION
## Description
fix:  report-detail-text-deregistration-wrong

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1394](https://cardanofoundation.atlassian.net/browse/MET-1394)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="899" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3ecb33f9-1330-41ff-98ee-f3c3e85599e4">


##### _After_

[comment]: <> (Add screenshots)
<img width="698" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9243b4df-50dc-4dc5-ae45-e6f98baac35d">



#### Safari
##### _Before_

same chrome

##### _After_

same chrome



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1394]: https://cardanofoundation.atlassian.net/browse/MET-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ