### PR TITLE
fix: MET-1441 remove field ROS

### DIFF
--- a/src/components/DelegationDetail/DelegationDetailList/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailList/index.tsx
@@ -3,13 +3,7 @@ import { parse, stringify } from "qs";
 import { useHistory, useLocation } from "react-router-dom";
 
 import { details } from "src/commons/routers";
-import {
-  formatADAFull,
-  formatDateTimeLocal,
-  formatPercent,
-  getShortWallet,
-  numberWithCommas
-} from "src/commons/utils/helper";
+import { formatADAFull, formatDateTimeLocal, getShortWallet, numberWithCommas } from "src/commons/utils/helper";
 import CopyButton from "src/components/commons/CopyButton";
 import CustomTooltip from "src/components/commons/CustomTooltip";
 import Table, { Column } from "src/components/commons/Table";
@@ -66,12 +60,6 @@ const DelegationEpochList = ({
       minWidth: "120px",
 
       render: (data) => <Box component={"span"}>{formatADAFull(data.fee)}</Box>
-    },
-    {
-      title: "ROS",
-      key: "ros",
-      minWidth: "120px",
-      render: (data) => formatPercent(data.ros ? data.ros / 100 : 0)
     }
   ];
 

--- a/src/components/DelegationDetail/DelegationDetailOverview/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailOverview/index.tsx
@@ -19,11 +19,6 @@ const DelegationDetailOverview: React.FC<IDelegationDetailOverview> = ({ data, l
       tooltip: "Last calculated gross return, as of the second last epoch"
     },
     {
-      title: "ROS",
-      value: formatPercent(data?.ros ? data?.ros / 100 : 0),
-      tooltip: "Gross average return during pool’s lifetime"
-    },
-    {
       title: "Fixed Cost(A)",
       value: formatADAFull(data?.cost),
       tooltip: ""

--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -4,7 +4,7 @@ import { Box } from "@mui/material";
 import { get } from "lodash";
 
 import Table, { Column } from "src/components/commons/Table";
-import { formatADAFull, formatPercent, getPageInfo, getShortWallet, toFixedBigNumber } from "src/commons/utils/helper";
+import { formatADAFull, formatPercent, getPageInfo, getShortWallet } from "src/commons/utils/helper";
 import { details } from "src/commons/routers";
 import { HeaderSearchIcon } from "src/commons/resources";
 import useFetchList from "src/commons/hooks/useFetchList";
@@ -115,16 +115,6 @@ const DelegationLists: React.FC = () => {
       key: "Reward",
       minWidth: "120px",
       render: (r) => <RateWithIcon value={r.reward} multiple={1} />
-    },
-    {
-      title: (
-        <CustomTooltip title="Gross average return during pool’s lifetime">
-          <span>Lifetime ROS</span>
-        </CustomTooltip>
-      ),
-      minWidth: "100px",
-      key: "lifetimeRos",
-      render: (r) => <Box component={"span"}>{toFixedBigNumber(r.lifetimeRos || 0, 2)}%</Box>
     },
     {
       title: "Fixed Cost (A)",

--- a/src/components/Home/TopDelegationPools/index.tsx
+++ b/src/components/Home/TopDelegationPools/index.tsx
@@ -4,7 +4,7 @@ import { get } from "lodash";
 
 import useFetch from "src/commons/hooks/useFetch";
 import { details, routers } from "src/commons/routers";
-import { formatADAFull, formatPercent, getShortWallet, toFixedBigNumber } from "src/commons/utils/helper";
+import { formatADAFull, formatPercent, getShortWallet } from "src/commons/utils/helper";
 import ViewAllButton from "src/components/commons/ViewAllButton";
 import { Column } from "src/components/commons/Table";
 import CustomTooltip from "src/components/commons/CustomTooltip";
@@ -82,15 +82,6 @@ const TopDelegationPools = () => {
       title: "Blocks Lifetime",
       key: "lifetimeBlock",
       render: (r) => r.lifetimeBlock || 0
-    },
-    {
-      title: (
-        <CustomTooltip title="Gross average return during pool’s lifetime">
-          <span>Lifetime ROS</span>
-        </CustomTooltip>
-      ),
-      key: "lifetimeRos",
-      render: (r) => `${toFixedBigNumber(r.lifetimeRos || 0, 2)}%`
     }
   ];
   return (


### PR DESCRIPTION
## Description

fix: MET-1441 remove field ROS

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1441](https://cardanofoundation.atlassian.net/browse/MET-1441)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

Before
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/df0a272a-e9d9-4c91-bba4-d561b0680aa8)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/e0a8c3bb-54e5-4b74-a04c-fe6cb2afca05)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/2b122d24-8493-4079-9317-99d74526a0db)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/fe2bd6e5-e76b-4f99-8dbb-d2be0bbc43d1)

After
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/a4a8c059-85fd-4c0d-8ccd-020360143669)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/3fa55cd6-c8cc-4a4d-8152-79bc4995c2c6)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/227bbb41-6f79-4273-b33d-d1f0fd70a02d)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/d729750e-9392-4347-9f7b-7815d0c697bd)


[MET-1441]: https://cardanofoundation.atlassian.net/browse/MET-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ