### PR TITLE
fix: Stake-address-registrarion-display-text-tot-delegated-to-any-poo…

### DIFF
--- a/src/components/commons/DetailView/DetailViewStakeKey.tsx
+++ b/src/components/commons/DetailView/DetailViewStakeKey.tsx
@@ -199,11 +199,15 @@ const DetailViewStakeKey: React.FC<DetailViewStakeKeyProps> = (props) => {
               <WrapDetailInfo>
                 <DetailLabel>Delegated to</DetailLabel>
               </WrapDetailInfo>
-              <CustomTooltip title={poolNameToolTip}>
-                <Box component={Link} display="inline-block" to={details.delegation(data.pool?.poolId)}>
-                  <DelegatedDetail>{poolName}</DelegatedDetail>
-                </Box>
-              </CustomTooltip>
+              {data.pool?.poolName || data.pool?.poolId ? (
+                <CustomTooltip title={poolNameToolTip}>
+                  <Box component={Link} display="inline-block" to={details.delegation(data.pool?.poolId)}>
+                    <DelegatedDetail>{poolName}</DelegatedDetail>
+                  </Box>
+                </CustomTooltip>
+              ) : (
+                "Not delegated to any pool"
+              )}
             </DetailsInfoItem>
             <DetailsInfoItem>
               <WrapDetailInfo>


### PR DESCRIPTION
## Description

bugfix/MET-615-Stake-address-registrarion-display-text-not-delegated-to-any-pool when value is null

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="756" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/bbe5f491-5784-4598-a7fa-5a33b5a1375c">

##### _After_

[comment]: <> (Add screenshots)
<img width="584" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/b5541b26-eb5d-41c2-9e56-4be2dcaa6510">

#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)



[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ