### PR TITLE
fix: MET-1465 table scroll over tbody

### DIFF
--- a/src/components/commons/Table/styles.ts
+++ b/src/components/commons/Table/styles.ts
@@ -158,6 +158,10 @@ export const Wrapper = styled(Box)<{ maxHeight?: number | string; height: number
   &::-webkit-scrollbar-thumb {
     background: transparent;
   }
+  &::-webkit-scrollbar-button:vertical:start:decrement {
+    height: 72px; 
+    display: block;
+  } 
   &:hover {
     &::-webkit-scrollbar-thumb {
       background: ${theme.palette.secondary.light};


### PR DESCRIPTION
## Description

Show only scrollbars inside the table that don't stretch to the title.


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1465](https://cardanofoundation.atlassian.net/browse/MET-1465)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|--------|
| ![Screenshot_39](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/bd32b577-c228-48af-ba08-3550c98bfc0a) | ![Screenshot_40](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/854261a4-7662-4f11-8ebc-83325d6eb30a) |


#### Safari

Same chrome

#### Responsive

No change


[MET-1465]: https://cardanofoundation.atlassian.net/browse/MET-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ