### PR TITLE
fix: Account-overview-no-display-full-email-address-in-larger-screen(…

### DIFF
--- a/src/components/commons/Layout/AccountLayout/styled.ts
+++ b/src/components/commons/Layout/AccountLayout/styled.ts
@@ -78,7 +78,7 @@ export const NavItemMobile = styled(Link)<{ active: boolean }>(({ theme, active 
 }));
 
 export const StyledUsername = styled(Box)`
-  max-width: 200px;
+  max-width: 100%;
   padding-left: ${({ theme }) => theme.spacing(1)};
   padding-right: ${({ theme }) => theme.spacing(1)};
   overflow: hidden;


### PR DESCRIPTION
## Description

fix: Account-overview-no-display-full-email-address-in-larger-screen

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="313" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/84ef3a47-d905-412a-acba-23f0868d4a2c">


##### _After_

[comment]: <> (Add screenshots)
<img width="332" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/958d97f4-507d-411b-8c84-f180a876e68b">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ