### PR TITLE
fix: Logo-iris-and-text-cardano-explorer-display-2-line( MET-1517)

### DIFF
--- a/src/components/commons/Layout/Header/index.tsx
+++ b/src/components/commons/Layout/Header/index.tsx
@@ -61,13 +61,20 @@ const Header: React.FC<RouteComponentProps> = (props) => {
       <HeaderBox home={home ? 1 : 0}>
         <HeaderMain home={home ? 1 : 0}>
           <Title home={home ? 1 : 0} data-testid="home-title">
-            <Box display={"flex"} alignItems={"center"} justifyContent={"center"} flexWrap={"wrap"}>
+            <Box
+              display={"flex"}
+              alignItems={"center"}
+              justifyContent={"center"}
+              flexDirection={isMobile ? "column" : "row"}
+            >
               <Box
                 component={"img"}
                 src={LogoCardano}
                 width={isGalaxyFoldSmall ? "30vw" : isMobile ? "20vw" : "auto"}
               />
-              <Box fontSize={isGalaxyFoldSmall ? "24px" : "auto"}>, a Cardano explorer</Box>
+              <Box fontSize={isGalaxyFoldSmall ? "24px" : "auto"}>
+                {isMobile ? "a Cardano explorer" : ", a Cardano explorer"}
+              </Box>
             </Box>
           </Title>
           <HeaderSearchContainer>{!pathMatched && <HeaderSearch home={home} />}</HeaderSearchContainer>


### PR DESCRIPTION
## Description

fix: When making the screen size smaller the Iris logo becomes out of proportion with the title text. Also, when the breakpoint is reached that the logo becomes above the text, the comma “,“ should be removed.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1517](https://cardanofoundation.atlassian.net/browse/MET-1517)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="183" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/1d4f2d6e-35ba-4195-be12-60eda0aabe2f">


##### _After_

[comment]: <> (Add screenshots)
<img width="230" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/934d36c9-4e29-4d44-8ece-ff24f7475329">



[MET-1517]: https://cardanofoundation.atlassian.net/browse/MET-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ