### PR TITLE
fix: News-section-add-boxshadow-and-remove-color-when-hover-arrows(ME…

### DIFF
--- a/src/components/Home/LatestStories/style.ts
+++ b/src/components/Home/LatestStories/style.ts
@@ -43,7 +43,7 @@ export const Item = styled(BoxRaised)`
   cursor: pointer;
   overflow: hidden;
   &:hover {
-    box-shadow: ${(props) => props.theme.shadow.card};
+    box-shadow: ${(props) => props.theme.shadow.cardHover};
   }
   display: flex;
   flex-direction: column;
@@ -163,7 +163,7 @@ export const NextSwiper = styled(Box)`
   align-items: center;
   cursor: pointer;
   &:hover {
-    background: ${(props) => props.theme.palette.purple["200"]};
+    transform: scale(1.1);
   }
   position: absolute;
   right: -10px;
@@ -176,6 +176,9 @@ export const NextSwiper = styled(Box)`
 export const PrevSwiper = styled(NextSwiper)`
   left: -10px;
   transform: rotate(180deg);
+  &:hover {
+    transform: rotate(180deg) scale(1.1) !important;
+  }
 `;
 
 export const CustomGrid = styled(Grid)`


### PR DESCRIPTION
## Description

fix: News-section-add-boxshadow-and-remove-color-when-hover-arrows, increament size of arrows when hovering.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1517](https://cardanofoundation.atlassian.net/browse/MET-1517)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="813" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/d8bdcfee-fe2a-459f-93db-f23aa93ded0e">


##### _After_

[comment]: <> (Add screenshots)
<img width="592" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/755f15e5-dc79-4d41-a1c7-cf9e3ddd0d49">
<img width="590" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5ddbf7ab-c7a8-4c9a-87d2-0ac1d0c82866">




[MET-1517]: https://cardanofoundation.atlassian.net/browse/MET-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ