### PR TITLE
fix: Contract-detail-modal-transaction(MET-1517)

### DIFF
--- a/src/components/ContractDiagrams/index.tsx
+++ b/src/components/ContractDiagrams/index.tsx
@@ -19,7 +19,8 @@ import {
   DatumnItem,
   IconContainer,
   CloseButton,
-  DataTitle
+  DataTitle,
+  TxHash
 } from "./styles";
 import CustomTooltip from "../commons/CustomTooltip";
 
@@ -39,22 +40,22 @@ export const ContractDiagrams = ({ item, txHash, handleClose }: IContractDiagram
   return (
     <ContractDiagramsContainer isTxPageView={!!txHash}>
       <ContractHeader>
-        <ContractText>
-          {txHash ? "Transactions" : "Contract"}
-          {handleClose ? (
-            <CustomTooltip title="Close">
-              <CloseButton onClick={handleClose}>
-                <CgClose />
-              </CloseButton>
-            </CustomTooltip>
-          ) : null}
-        </ContractText>
+        <ContractText>{txHash ? "Transactions" : "Contract"}</ContractText>
+        {handleClose ? (
+          <CustomTooltip title="Close">
+            <CloseButton onClick={handleClose}>
+              <CgClose />
+            </CloseButton>
+          </CustomTooltip>
+        ) : null}
+      </ContractHeader>
+      <TxHash>
         <Link to={linkToPage()}>
           <ContractAddress data-testid={`contract-hash-${txHash || item.address || item.scriptHash}`}>
             {txHash || item.address || item.scriptHash}
           </ContractAddress>
         </Link>
-      </ContractHeader>
+      </TxHash>
       <ContractRedeemer item={item} txHash={txHash} />
       {item.datumHashIn && (
         <>

--- a/src/components/ContractDiagrams/styles.ts
+++ b/src/components/ContractDiagrams/styles.ts
@@ -2,17 +2,23 @@ import { styled, Box, Typography, IconButton } from "@mui/material";
 
 export const ContractDiagramsContainer = styled(Box)<{ isTxPageView?: boolean }>`
   background: ${(props) => props.theme.palette.secondary[0]};
-  padding: 25px;
+  padding: 25px 0 25px 25px;
   border-radius: 10px;
   margin-bottom: 30px;
+  ${(props) => props.theme.breakpoints.down("sm")} {
+    padding: 0 25px 25px 0;
+  }
 `;
 
-export const ContractHeader = styled(Box)`
+export const TxHash = styled(Box)`
   text-align: left;
+  background-color: ${({ theme }) => theme.palette.primary[200]};
+  border-radius: 8px;
+  padding: 16px 20px;
 `;
 
 export const ContractText = styled(Typography)`
-  font-size: 14px;
+  font-size: var(--font-size-text-lager);
   font-weight: 700;
   display: flex;
   justify-content: space-between;
@@ -24,7 +30,6 @@ export const ContractAddress = styled(Box)`
   color: ${(props) => props.theme.palette.primary.main};
   font-size: 14px;
   font-weight: 400;
-  padding-top: 10px;
   word-break: break-all;
 `;
 
@@ -120,4 +125,10 @@ export const IconContainer = styled(Box)`
 export const CloseButton = styled(IconButton)`
   color: ${(props) => props.theme.palette.secondary[600]};
   padding: 5.5px;
+`;
+
+export const ContractHeader = styled(Box)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;


### PR DESCRIPTION
## Description

fix: Contract detail modal transactions change color header and add padding for it look like design 

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1517](https://cardanofoundation.atlassian.net/browse/MET-1517)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="451" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/47571e1e-fa5b-4f0d-9ed8-3b9580a41b55">



##### _After_

[comment]: <> (Add screenshots)
<img width="573" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/c5c453d2-7e73-438e-8d2a-dd615ba6aeb0">



#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)
<img width="179" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/48ec66c5-b984-402b-9472-4c0b79436e47">


##### _After_

[comment]: <> (Add screenshots)
<img width="196" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/31c06e4a-e29e-4658-b130-fad739098d07">





[MET-1517]: https://cardanofoundation.atlassian.net/browse/MET-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ