### PR TITLE
fix: Card lastest transaction shouldn't break in two line(MET-1517)

### DIFF
--- a/src/components/Home/LatestTransactions/index.tsx
+++ b/src/components/Home/LatestTransactions/index.tsx
@@ -92,9 +92,11 @@ const LatestTransactions: React.FC = () => {
                       <ItemHeader>
                         <LatestTransactionItemHeader>
                           <HeaderStatus status={status as TRANSACTION_STATUS}>{status}</HeaderStatus>
-                          <PriceImage src={ADAIcon} alt="check green" />
+                          <Box display={"flex"} alignItems={"flex-start"}>
+                            <PriveValue>{formatADAFull(amount)}</PriveValue>
+                            <PriceImage src={ADAIcon} alt="check green" />
+                          </Box>
                         </LatestTransactionItemHeader>
-                        <PriveValue>{formatADAFull(amount)}</PriveValue>
                       </ItemHeader>
                       <ItemDetail>
                         <Box display="flex" alignItems="center">

--- a/src/components/Home/LatestTransactions/style.ts
+++ b/src/components/Home/LatestTransactions/style.ts
@@ -101,13 +101,12 @@ export const RowItem = styled(Box)`
     margin-top: 0;
     margin-right: 10px;
   }
-}
 `;
 
 export const PriceImage = styled("img")`
-  height: 45px;
+  height: 25px;
   ${({ theme }) => theme.breakpoints.down("sm")} {
-    height: 30px;
+    height: 20px;
   }
 `;
 
@@ -117,6 +116,8 @@ export const PriveValue = styled("span")`
   line-height: 1;
   color: ${(props) => props.theme.palette.secondary.main};
   text-align: end;
+  margin-right: 5px;
+  word-break: break-all;
 `;
 
 export const ItemDetail = styled("div")`


### PR DESCRIPTION
## Description
fix: Card lastest transaction shouldn't break in two line

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1517](https://cardanofoundation.atlassian.net/browse/MET-1517)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="821" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5d6356a0-4a54-4b96-941b-f1c21cdb1688">


##### _After_

[comment]: <> (Add screenshots)
<img width="583" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/9b8c2d3d-5f6f-4125-a68c-3dad14c6f5ab">


#### Safari
##### _Before_

same chrome

##### _After_

same chrome

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)
<img width="279" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/dbbdf11f-9015-4af1-9754-5cb939c727ad">


##### _After_

[comment]: <> (Add screenshots)
<img width="281" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/3786b7a5-9968-4bd5-b7ca-deb18868bbad">




[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MET-1517]: https://cardanofoundation.atlassian.net/browse/MET-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ