### PR TITLE
fix: MET-615 handle no asset name in minting tab of transaction detail

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/Minting/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/Minting/index.tsx
@@ -7,7 +7,8 @@ import ScriptModal from "src/components/ScriptModal";
 import { PolicyScriptIcon } from "src/commons/resources";
 import { Logo } from "src/pages/Token/styles";
 import { details } from "src/commons/routers";
-import { formatAmount } from "src/commons/utils/helper";
+import CustomTooltip from "src/components/commons/CustomTooltip";
+import { formatAmount, getShortWallet } from "src/commons/utils/helper";
 
 import { Amount, AssetName, LogoEmpty, TableMinting } from "./styles";
 
@@ -35,7 +36,13 @@ const Minting: React.FC<MintingProps> = ({ data }) => {
                 color={({ palette }) => `${palette.primary.main} !important`}
                 to={details.token(r.assetId)}
               >
-                {r.assetName}
+                {r.assetName ? (
+                  r.assetName
+                ) : (
+                  <CustomTooltip title={r.assetId}>
+                    <Box component={"span"}>{getShortWallet(r.assetId)}</Box>
+                  </CustomTooltip>
+                )}
               </Box>
             </>
           </AssetName>


### PR DESCRIPTION
## Description

Handle the absence of an asset name in the minting tab of the transaction detail.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ