### PR TITLE
fix: icon-ADA-too-thin-and-remove-ADA-after-live-stake( MET-1413)

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -207,9 +207,7 @@ const HomeStatistic = () => {
                       src={LiveStakeIcon}
                       alt="Total ADA Stake"
                     />
-                    <Name data-testid="live-stake-box-title">
-                      Live Stake <StyledAdaLogoIcon />
-                    </Name>
+                    <Name data-testid="live-stake-box-title">Live Stake</Name>
                   </Box>
                 </Box>
                 <Box>
@@ -243,7 +241,9 @@ const HomeStatistic = () => {
                   </Box>
                   <Box fontSize={"12px"} color={({ palette }) => palette.secondary.light}>
                     <CustomTooltip title={"Of the max supply"}>
-                      <span>Circulating supply (ADA): </span>
+                      <span>
+                        Circulating supply <StyledAdaLogoIcon />:{" "}
+                      </span>
                     </CustomTooltip>
                     <CustomTooltip title={numberWithCommas(supply)}>
                       <span data-testid="circulating-supply-value">{formatADA(circulatingSupply.toString())}</span>

--- a/src/components/Home/Statistic/style.ts
+++ b/src/components/Home/Statistic/style.ts
@@ -148,5 +148,5 @@ export const Link = styled("a")`
 
 export const StyledAdaLogoIcon = styled(AdaLogoIcon)(({ theme }) => ({
   fontSize: 12,
-  color: theme.palette.text.secondary
+  color: theme.palette.secondary.main
 }));


### PR DESCRIPTION
## Description

There should be no(A) after Live Stake in the title of the card and Ada's symbol is too thin 

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1413](https://cardanofoundation.atlassian.net/browse/MET-1413)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/14948986-2219-4e7f-be46-cbbea6a19aef)

****

##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/0707ebcb-1e31-40e5-9983-c6e02996708e)




[MET-1413]: https://cardanofoundation.atlassian.net/browse/MET-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ