### PR TITLE
fix: show slot wrong in statistic card

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -163,7 +163,11 @@ const HomeStatistic = () => {
                   <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"} flexWrap={"wrap"}>
                     <Title data-testid="current-epoch-number">{numberWithCommas(currentEpoch?.no)}</Title>
                     <Box color={({ palette }) => palette.secondary.light}>
-                      Slot: {numberWithCommas(currentEpoch?.slot % MAX_SLOT_EPOCH)}/ {numberWithCommas(MAX_SLOT_EPOCH)}
+                      Slot:{" "}
+                      {moment(currentEpoch?.endTime).isAfter(moment())
+                        ? numberWithCommas(currentEpoch?.slot)
+                        : numberWithCommas(MAX_SLOT_EPOCH)}
+                      / {numberWithCommas(MAX_SLOT_EPOCH)}
                     </Box>
                   </Box>
                   <Progress>


### PR DESCRIPTION
## Description

show slot srong in statistic card(home page) when BE (clawer and comsumer stop)

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/a458a446-9a21-42e2-89e0-51ae6328e795)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/709470e3-e88f-4c4a-84e4-f0868d586180)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)