### PR TITLE
fix: MET-1559 search address and pool wrong

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -18,6 +18,7 @@ import { Image, PoolName, SearchContainer, StyledInput, StyledLinearProgress, Su
 const DelegationLists: React.FC = () => {
   const history = useHistory<{ tickerNameSearch?: string; fromPath?: SpecialPath }>();
   const { tickerNameSearch = "" } = history.location.state || {};
+  // eslint-disable-next-line no-console
 
   const [value, setValue] = useState(decodeURIComponent(tickerNameSearch));
   const [search, setSearch] = useState(decodeURIComponent(tickerNameSearch));
@@ -25,6 +26,14 @@ const DelegationLists: React.FC = () => {
   const [size, setSize] = useState(50);
   const [sort, setSort] = useState<string>("");
   const tableRef = useRef(null);
+
+  useEffect(() => {
+    if (tickerNameSearch) {
+      setSearch(decodeURIComponent(tickerNameSearch));
+      setValue(decodeURIComponent(tickerNameSearch));
+    }
+  }, [tickerNameSearch]);
+
   const fetchData = useFetchList<Delegators>(
     API.DELEGATION.POOL_LIST,
     { page: page - 1, size, search, sort },

--- a/src/components/commons/Layout/Header/HeaderSearch/index.tsx
+++ b/src/components/commons/Layout/Header/HeaderSearch/index.tsx
@@ -111,6 +111,7 @@ const URL_FETCH_DETAIL = {
   blocks: (block: number) => `${API.BLOCK.DETAIL}/${block}`,
   txs: (trx: string) => `${API.TRANSACTION.DETAIL}/${trx}`,
   addresses: (address: string) => `${API.ADDRESS.DETAIL}/${address}`,
+  stake: (stake: string) => `${API.STAKE.DETAIL}/${stake}`,
   policies: (policy: string) => `${API.POLICY}/${policy}`
 };
 
@@ -289,9 +290,20 @@ const HeaderSearch: React.FC<Props> = ({ home, callback, setShowErrorMobile, his
 
     if (!["all", "tokens", "delegations/pool-detail-header"].includes(option?.value || "")) {
       setLoading(true);
-      const url = URL_FETCH_DETAIL[option?.value as keyof typeof URL_FETCH_DETAIL]
-        ? URL_FETCH_DETAIL[option?.value as keyof typeof URL_FETCH_DETAIL](search as never)
-        : "";
+      let url = "";
+
+      if (option?.value === "addresses") {
+        if (search.trim().startsWith("stake")) {
+          url = URL_FETCH_DETAIL["stake"](search);
+        } else {
+          url = URL_FETCH_DETAIL["addresses"](search);
+        }
+      } else {
+        url = URL_FETCH_DETAIL[option?.value as keyof typeof URL_FETCH_DETAIL]
+          ? URL_FETCH_DETAIL[option?.value as keyof typeof URL_FETCH_DETAIL](search as never)
+          : "";
+      }
+
       try {
         await defaultAxios.get(url);
       } catch (error) {


### PR DESCRIPTION
## Description

- allow search stake when select option addresses
- search pool in pool page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue:[ [link]](https://cardanofoundation.atlassian.net/browse/MET-1559)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/4e2d45a6-9b97-4b9d-a72e-a599ec2d5236)

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/712dec9f-4e67-4ead-b0b5-85d55b813115)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/b630c88d-2ca3-4c8f-92d0-bd5169b5c1da)

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/4d2d6831-dae8-4368-8386-8f68b7ef9dff)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)