### PR TITLE
fix: transaction protocol update tooltip and popup issue

### DIFF
--- a/src/components/ParseScriptModal/ParseScriptModal.test.tsx
+++ b/src/components/ParseScriptModal/ParseScriptModal.test.tsx
@@ -37,13 +37,14 @@ describe("ParseScriptModal component", () => {
   });
   it("should component render", () => {
     render(<ParseScriptModal {...mockProps} />);
+    expect(screen.getByTestId(/parse-script-modal/i)).toBeInTheDocument();
     expect(screen.getByText(/parse script/i)).toBeInTheDocument();
     expect(screen.getByText(/enter your script below:/i)).toBeInTheDocument();
   });
 
   it("should modal closed", () => {
     render(<ParseScriptModal {...mockProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /icon close/i }));
+    fireEvent.click(screen.getByTestId("close-modal-button"));
     expect(mockProps.onClose).toBeCalled();
   });
 });

--- a/src/components/ParseScriptModal/index.tsx
+++ b/src/components/ParseScriptModal/index.tsx
@@ -1,8 +1,7 @@
 import { useTheme } from "@mui/material";
 import { JsonViewer } from "@textea/json-viewer";
 
-import CustomModal from "../commons/CustomModal";
-import { SubTitle, ViewJson } from "./styles";
+import { StyledCustomModal, SubTitle, ViewJson } from "./styles";
 
 interface ParseScriptModalProps {
   open: boolean;
@@ -24,7 +23,7 @@ const ParseScriptModal: React.FC<ParseScriptModalProps> = ({ script, subTitle, .
   };
 
   return (
-    <CustomModal {...props}>
+    <StyledCustomModal {...props} data-testid="parse-script-modal">
       {subTitle && <SubTitle>{subTitle}</SubTitle>}
       <ViewJson maxHeight={subTitle ? "60vh" : "70vh"}>
         <JsonViewer
@@ -37,7 +36,7 @@ const ParseScriptModal: React.FC<ParseScriptModalProps> = ({ script, subTitle, .
           rootName={false}
         />
       </ViewJson>
-    </CustomModal>
+    </StyledCustomModal>
   );
 };
 

--- a/src/components/ParseScriptModal/styles.ts
+++ b/src/components/ParseScriptModal/styles.ts
@@ -1,5 +1,13 @@
 import { Box, styled } from "@mui/material";
 
+import CustomModal from "../commons/CustomModal";
+
+export const StyledCustomModal = styled(CustomModal)(() => ({
+  boxSizing: "border-box",
+  maxHeight: "70vh",
+  overflow: "hidden"
+}));
+
 export const SubTitle = styled(Box)(({ theme }) => ({
   color: theme.palette.secondary.main,
   marginBottom: 8
@@ -13,7 +21,7 @@ export const ViewJson = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2),
   boxSizing: "border-box",
   overflow: "auto",
-  width: "min(80vw, 800px)",
+  width: "min(90vw, 800px)",
 
   "& .MuiSvgIcon-root": {
     display: "none !important"


### PR DESCRIPTION
## Description

Fix issue relate transaction protocol update: 
 - CostModel value: Don't show json format in CostModel modal.
 - Text content value: don't have tooltip when hover.
 
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No ticket jira

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

| Before | After |
|--------|--------|
| ![Screenshot_67](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/1417b385-80b9-41c2-8474-198a260b7159) | ![Screenshot_66](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/e04af9e6-fe35-4d26-a48c-2dfef2d7518f) |

| Before | After |
|--------|--------|
| ![Screenshot_69](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/b432c155-c775-464e-a444-cbd36201f173) | ![Screenshot_68](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/5a7f84af-290c-4cbc-b12c-cb692537a512) |

#### Safari

Same Chrome

#### Responsive

Tablet: 
| Before | After |
|--------|--------|
| ![Screenshot_76](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/cda10652-45db-419c-89c8-8604107b04a9) | ![Screenshot_79](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/2144d930-8eba-451b-bc4a-d92ae0d21280) |

| Before | After |
|--------|--------|
| ![Screenshot_73](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/dd530ec6-071c-433b-89a3-1893a9e1597e) | ![Screenshot_70](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/77771ae3-d51f-49a1-98cd-5be06fc956af) |


Mobile: 
| Before | After |
|--------|--------|
| ![Screenshot_77](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/e50fb4b5-b410-4430-809f-d1176c78e23f) | ![Screenshot_78](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/54509b24-af85-4d8d-815e-3e6fc3a79f47) |

| Before | After |
|--------|--------|
| ![Screenshot_72](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/22a69738-aa51-40c8-a3c9-2e52e0193764) | ![Screenshot_71](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/18ca3a37-cde9-4f42-a87b-5167c80a751c) |