### PR TITLE
fix: finding-1-hide-the-main-logo-when-mobile-menu-open(MET-1553)

### DIFF
--- a/src/components/commons/Layout/Header/index.tsx
+++ b/src/components/commons/Layout/Header/index.tsx
@@ -81,7 +81,7 @@ const Header: React.FC<RouteComponentProps> = (props) => {
         </HeaderMain>
         <HeaderTop data-testid="header-top" ref={refElement}>
           <HeaderLogoLink to="/" data-testid="header-logo">
-            <HeaderLogo src={LogoIcon} alt="logo desktop" />
+            {!sidebar && <HeaderLogo src={LogoIcon} alt="logo desktop" />}
           </HeaderLogoLink>
           <SideBarRight>
             <NetworkContainer>


### PR DESCRIPTION
## Description

Hide the main logo when mobile menu open, because we already have logo on menu

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1553](https://cardanofoundation.atlassian.net/browse/MET-1553)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

<img width="199" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/edacfea6-02b3-44d0-8d80-daec223a5c81">


##### _After_

[comment]: <> (Add screenshots)

<img width="197" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/1d07b3c1-726e-472c-8c59-47475a417d53">


[MET-1553]: https://cardanofoundation.atlassian.net/browse/MET-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ