### PR TITLE
fix: MET-1558 calender range seems not to apply new branding colors

### DIFF
--- a/src/components/commons/CustomDatePicker/index.tsx
+++ b/src/components/commons/CustomDatePicker/index.tsx
@@ -6,6 +6,7 @@ import moment from "moment";
 import { BsFillCaretDownFill } from "react-icons/bs";
 import { IoIosArrowBack, IoIosArrowForward, IoMdClose } from "react-icons/io";
 import DatePicker, { ReactDatePickerProps } from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 
 import { DateRangeIcon } from "src/commons/resources";
 import { useScreen } from "src/commons/hooks/useScreen";
@@ -16,30 +17,17 @@ import {
   HiddenScroll,
   MyGrid,
   PickerPortalContainer,
+  PlaceHolder,
   SelectDateButton,
   SelectYear,
+  SelectedDay,
+  StyledDay,
   WrapCustomDatePicker
 } from "./styles";
-import "react-datepicker/dist/react-datepicker.css";
 
 export type IDate = Date | null;
 
 export type IDateRange = [IDate, IDate];
-
-const MONTHS = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-];
 
 export interface ICustomDatePicker {
   dateRange: IDateRange;
@@ -112,6 +100,30 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width, setOpen]);
 
+  const renderDayContents = (dayOfMonth: number, date?: Date | undefined, selectedDate?: IDate) => {
+    if (!(date && startDate && endDate)) return dayOfMonth;
+    if (moment(date).isBefore(startDate) || moment(date).isAfter(endDate)) return dayOfMonth;
+
+    const mDate = moment(date),
+      isStartDate = mDate.isSame(startDate),
+      isEndDate = mDate.isSame(endDate),
+      isStartWeek = mDate.weekday() === 0,
+      isEndWeek = mDate.weekday() === 6,
+      isStartMonth = mDate.isSame(moment(date).startOf("month"), "date"),
+      isEndMonth = mDate.isSame(moment(date).endOf("month"), "date");
+
+    let borderRadius = "0%";
+    if (isStartDate || isStartWeek || isStartMonth) borderRadius = "50% 0% 0% 50%";
+    if (isEndDate || isEndWeek || isEndMonth) borderRadius = "0% 50% 50% 0%";
+    if ((isStartDate || isStartWeek || isStartMonth) && (isEndDate || isEndWeek || isEndMonth)) borderRadius = "50%";
+
+    return (
+      <StyledDay borderRadius={borderRadius}>
+        {!moment(date).isSame(selectedDate) ? dayOfMonth : <SelectedDay>{dayOfMonth}</SelectedDay>}
+      </StyledDay>
+    );
+  };
+
   return (
     <>
       <WrapCustomDatePicker data-testid="date-range-picker" onClick={handleToggle} ref={ref}>
@@ -130,7 +142,7 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
             <span> {endDate ? moment(endDate).format("MM/DD/YYYY") : ""}</span>
           </Box>
         ) : (
-          <Box sx={{ opacity: 0.42, color: ({ palette }) => palette.secondary.light }}>dd/mm/yyyy</Box>
+          <PlaceHolder>dd/mm/yyyy</PlaceHolder>
         )}
         <SelectDateButton>
           <DateRangeIcon />
@@ -147,6 +159,7 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
             onChange={(value) => setDateRange([value, endDate])}
             hideFuture={hideFuture}
             maxDate={hideFuture ? endDate || lastDayOfCurrentMonth : endDate}
+            renderDayContents={(dayOfMonth, date) => renderDayContents(dayOfMonth, date, startDate)}
           />
           <SingleDatePicker
             itemKey={2}
@@ -161,6 +174,7 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
             hideFuture={hideFuture}
             minDate={startDate}
             maxDate={hideFuture ? lastDayOfCurrentMonth : null}
+            renderDayContents={(dayOfMonth, date) => renderDayContents(dayOfMonth, date, endDate)}
           />
           <CloseButton onClick={handleToggle} sx={{ display: open ? "inline-flex" : "none" }}>
             <IoMdClose size={20} />
@@ -228,7 +242,7 @@ export const SingleDatePicker = (props: SingleDatePickerProps) => {
         }) => (
           <Box display="flex" justifyContent="space-between" alignItems="center">
             <Box pl="12px" fontWeight={600} fontSize="16px" display="flex" alignItems="center">
-              {MONTHS[moment(date).month()]} {moment(date).year()}
+              {moment(date).format("MMMM YYYY")}
               <IconButton
                 ref={(ref) => (toggleRef.current = ref)}
                 onClick={() => setYearModal(!yearModal)}

--- a/src/components/commons/CustomDatePicker/styles.ts
+++ b/src/components/commons/CustomDatePicker/styles.ts
@@ -80,14 +80,14 @@ export const PickerPortalContainer = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  width: 322,
-  transform: "translate(-322px, 0)",
+  width: 316,
+  transform: "translate(-316px, 0)",
   [theme.breakpoints.down(650)]: {
     top: "50vh !important",
     left: "50vw !important",
     width: 0,
-    height: 660,
-    transform: "translate(-161px, -340px)",
+    height: 668,
+    transform: "translate(-156px, -348px)",
     flexDirection: "column"
   }
 }));
@@ -95,7 +95,7 @@ export const PickerPortalContainer = styled(Box)(({ theme }) => ({
 export const CloseButton = styled(IconButton)(({ theme }) => ({
   position: "absolute",
   top: 24,
-  right: -322,
+  right: -316,
   width: 24,
   height: 24,
   border: `1px solid ${theme.palette.primary[200]}`,
@@ -111,7 +111,8 @@ export const DatePickerContainer = styled(Box)(({ theme }) => ({
   height: 1,
   "div[class=react-datepicker]": {
     display: "flex",
-    minHeight: 315
+    minHeight: 352,
+    fontFamily: theme.typography.fontFamily
   },
   "&:first-of-type div[class=react-datepicker]": {
     borderRightWidth: 0,
@@ -136,9 +137,12 @@ export const DatePickerContainer = styled(Box)(({ theme }) => ({
     transform: "translate(164px, 0px) !important"
   },
   "div[class*=react-datepicker__header]": {
-    backgroundColor: "#fff",
+    backgroundColor: theme.palette.secondary[0],
     borderBottom: 0,
     paddingBottom: 5
+  },
+  "div[class=react-datepicker__month]": {
+    margin: 8
   },
   "div[class*=react-datepicker__month-container]": {
     padding: "20px 10px 0px"
@@ -148,40 +152,42 @@ export const DatePickerContainer = styled(Box)(({ theme }) => ({
     height: "0 !important"
   },
   [`div[class*="react-datepicker__day "]`]: {
-    width: 36,
-    height: 36,
+    width: 40,
+    height: 40,
     borderRadius: "50% !important",
     display: "inline-grid",
+    justifyContent: "center",
     alignItems: "center",
-    margin: "0 0.166rem"
+    margin: "1px 0"
   },
   "div[class=react-datepicker__day-name]": {
-    width: 36,
-    height: 20
+    width: 40,
+    height: 20,
+    margin: "2.5px 0"
   },
   "div[class*=react-datepicker__day--selected]": {
-    backgroundColor: "#53a57b",
-    color: "white",
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.secondary[0],
     "&:hover": {
-      backgroundColor: "#53a57b",
-      color: "white"
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.secondary[0]
     }
   },
   "div[class*=react-datepicker__day--in-selecting-range]": {
-    backgroundColor: "#53a57b9b",
-    color: "white"
+    backgroundColor: alpha(theme.palette.primary.main, 60),
+    color: theme.palette.secondary[0]
   },
   "div[class*=react-datepicker__day--keyboard-selected]": {
-    backgroundColor: "#53a57b",
-    color: "white",
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.secondary[0],
     "&hover": {
-      backgroundColor: "#53a57b",
-      color: "white"
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.secondary[0]
     }
   },
   "div[class*=react-datepicker__day--in-range]": {
-    backgroundColor: "#53a57b",
-    color: "white"
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.secondary[0]
   },
   [theme.breakpoints.down(650)]: {
     "div[class=react-datepicker__triangle]": {
@@ -209,4 +215,30 @@ export const DatePickerContainer = styled(Box)(({ theme }) => ({
       }
     }
   }
+}));
+
+export const PlaceHolder = styled(Box)(({ theme }) => ({
+  color: theme.palette.secondary.light
+}));
+
+export const StyledDay = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.primary[200],
+  width: 41,
+  height: 40,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  boxSizing: "border-box"
+}));
+
+export const SelectedDay = styled(Box)(({ theme }) => ({
+  color: theme.palette.secondary[0],
+  backgroundColor: theme.palette.primary.main,
+  width: 40,
+  height: 40,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  borderRadius: "50%",
+  boxSizing: "border-box"
 }));


### PR DESCRIPTION
## Description

MET-1558: Calendar range seems not to apply new branding colours

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1558](https://cardanofoundation.atlassian.net/browse/MET-1558)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|---------|
| ![Screenshot_83](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/a964d951-c7c1-4d1a-a9f7-6cea9b5c6ce5) | ![Screenshot_82](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/7f7a80b0-e05d-4bfc-ad85-bac0b5a4d9b6) |


[MET-1558]: https://cardanofoundation.atlassian.net/browse/MET-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ