### PR TITLE
fix: MET-1558 wrong color after selected date range

### DIFF
--- a/src/components/commons/CustomDatePicker/index.tsx
+++ b/src/components/commons/CustomDatePicker/index.tsx
@@ -102,11 +102,11 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
 
   const renderDayContents = (dayOfMonth: number, date?: Date | undefined, selectedDate?: IDate) => {
     if (!(date && startDate && endDate)) return dayOfMonth;
-    if (moment(date).isBefore(startDate) || moment(date).isAfter(endDate)) return dayOfMonth;
+    if (moment(date).isBefore(startDate, "date") || moment(date).isAfter(endDate, "date")) return dayOfMonth;
 
     const mDate = moment(date),
-      isStartDate = mDate.isSame(startDate),
-      isEndDate = mDate.isSame(endDate),
+      isStartDate = mDate.isSame(startDate, "date"),
+      isEndDate = mDate.isSame(endDate, "date"),
       isStartWeek = mDate.weekday() === 0,
       isEndWeek = mDate.weekday() === 6,
       isStartMonth = mDate.isSame(moment(date).startOf("month"), "date"),
@@ -119,7 +119,7 @@ const CustomDatePicker = (props: ICustomDatePicker) => {
 
     return (
       <StyledDay borderRadius={borderRadius}>
-        {!moment(date).isSame(selectedDate) ? dayOfMonth : <SelectedDay>{dayOfMonth}</SelectedDay>}
+        {!moment(date).isSame(selectedDate, "date") ? dayOfMonth : <SelectedDay>{dayOfMonth}</SelectedDay>}
       </StyledDay>
     );
   };

--- a/src/components/commons/CustomDatePicker/styles.ts
+++ b/src/components/commons/CustomDatePicker/styles.ts
@@ -223,12 +223,15 @@ export const PlaceHolder = styled(Box)(({ theme }) => ({
 
 export const StyledDay = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.primary[200],
-  width: 41,
+  width: 40,
   height: 40,
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  boxSizing: "border-box"
+  boxSizing: "border-box",
+  [theme.breakpoints.down(650)]: {
+    width: 41
+  }
 }));
 
 export const SelectedDay = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
## Description

Fix bug: wrong color after selected date range.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1558](https://cardanofoundation.atlassian.net/browse/MET-1558)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|---------|
| ![Screenshot_86](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/d7bc6d50-27c1-4ccf-9dc3-5f8394ea7387) | ![Screenshot_85](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/26896ad0-b901-4f91-b458-3f8fed7a9635) |


[MET-1558]: https://cardanofoundation.atlassian.net/browse/MET-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ