### PR TITLE
fix: MET-615 fix icon is not show in ipad pro m1

### DIFF
--- a/src/commons/resources/icons/ADAsymbol.svg
+++ b/src/commons/resources/icons/ADAsymbol.svg
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76.8 86.04">
-  <defs>
-    <style>
-      .cls-1 {
-        fill: #434656;
-      }
-    </style>
-  </defs>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76.8 86.04" fill="#434656">
   <path class="cls-1" d="m2.76,60.24v-9.48h10.44l3.48-9.24H2.76v-9.48h17.52L32.4,0h13.2l11.52,32.04h16.32v9.48h-12.84l3.36,9.24h9.48v9.48h-6l9.36,25.8h-12.84l-8.64-25.8H21.24l-9.36,25.8H0l9.6-25.8H2.76Zm48.72-9.48l-3.24-9.24h-20.28l-3.36,9.24h26.88Zm-20.16-18.72h13.8l-6.72-19.32-7.08,19.32Z"/>
 </svg>

--- a/src/commons/resources/index.ts
+++ b/src/commons/resources/index.ts
@@ -220,7 +220,6 @@ export { ReactComponent as TimeIcon } from "./icons/Staking/TimeIcon.svg";
 export { ReactComponent as ADAOrangeIcon } from "./icons/Staking/ADAOrangeIcon.svg";
 export { ReactComponent as FilterIC } from "./icons/filter-ic.svg";
 export { ReactComponent as CalenderIcon } from "./icons/calender-pale.svg";
-export { ReactComponent as AIconGreen } from "./icons/AIconGreen.svg";
 export { ReactComponent as ArrowFromTopIcon } from "./icons/arrow-from-top.svg";
 export { ReactComponent as ArrowFromBottomIcon } from "./icons/arrow-from-bottom.svg";
 export { ReactComponent as HashtagIcon } from "./icons/hashtag.svg";

--- a/src/components/commons/OverviewStaking/index.tsx
+++ b/src/components/commons/OverviewStaking/index.tsx
@@ -1,11 +1,12 @@
-import { Box } from "@mui/material";
+import { Box, useTheme } from "@mui/material";
 import React from "react";
 
-import { AIconGreen, HashtagIcon, TimerIcon } from "src/commons/resources";
+import { HashtagIcon, TimerIcon } from "src/commons/resources";
 import { formatADAFull, formatDateTimeLocal, getShortHash } from "src/commons/utils/helper";
 
 import { OverviewIcon, OverviewTitle, Card } from "./styles";
 import CustomIcon from "../CustomIcon";
+import ADAicon from "../ADAIcon";
 
 interface Props {
   hash: string;
@@ -24,6 +25,7 @@ interface Props {
 
 const OverviewStaking: React.FC<Props> = ({ item, ...props }) => {
   const { hash, amount, time, onClick } = props;
+  const theme = useTheme();
 
   return (
     <Card onClick={() => onClick(item)} data-testid="overview-staking">
@@ -37,7 +39,7 @@ const OverviewStaking: React.FC<Props> = ({ item, ...props }) => {
       </Box>
       <Box display={"flex"}>
         <OverviewIcon>
-          <CustomIcon icon={AIconGreen} height={14} fill="currentColor" color={(theme) => theme.palette.primary.main} />
+          <ADAicon style={{ fill: theme.palette.primary.main }} />
         </OverviewIcon>
         <Box marginLeft={"10px"}>
           <OverviewTitle data-testid="overview-staking-amount">{formatADAFull(amount)}</OverviewTitle>


### PR DESCRIPTION
## Description
fix: MET-615 fix icon not show in ipad pro m1

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [MET-615](https://cardanofoundation.atlassian.net/browse/MET-615)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-615]: https://cardanofoundation.atlassian.net/browse/MET-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ