### PR TITLE
fix: menu active invalid when change tab in stake and pool detail page

### DIFF
--- a/src/commons/utils/api.ts
+++ b/src/commons/utils/api.ts
@@ -17,7 +17,7 @@ export const API = {
     HEADER: "delegations/header",
     POOL_ANALYTICS: "delegations/pool-detail-analytics",
     POOL_DETAIL_HEADER: "delegations/pool-detail-header",
-    POOL_DETAIL: "delegations/pool-detail",
+    POOL_DETAIL: (tab: "epochs" | "delegators") => `delegations/pool-detail-${tab}`,
     POOL_LIST: "delegations/pool-list",
     TOP: "delegations/top"
   },

--- a/src/components/DelegationDetail/DelegationDetailList/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailList/index.tsx
@@ -27,7 +27,7 @@ const DelegationEpochList = ({
   const { search } = useLocation();
   const query = parse(search.split("?")[1]);
   const setQuery = (query: any) => {
-    history.replace({ search: stringify(query) });
+    history.replace({ search: stringify(query) }, history.location.state);
   };
   const columns: Column<DelegationEpoch>[] = [
     {
@@ -109,7 +109,7 @@ const DelegationStakingDelegatorsList = ({
   const query = parse(search.split("?")[1]);
   const history = useHistory();
   const setQuery = (query: any) => {
-    history.replace({ search: stringify(query) });
+    history.replace({ search: stringify(query) }, history.location.state);
   };
   const columns: Column<StakingDelegators>[] = [
     {

--- a/src/components/DelegationDetail/DelegationDetailOverview/DelegationDetailOverview.test.tsx
+++ b/src/components/DelegationDetail/DelegationDetailOverview/DelegationDetailOverview.test.tsx
@@ -31,7 +31,7 @@ describe("DelegationDetailOverview component", () => {
   it("should component render", () => {
     render(<DelegationDetailOverview {...mockProps} />);
     expect(screen.getByText(/margin/i)).toBeInTheDocument();
-    expect(screen.getByText(/pledge\(a\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/declared pledge/i)).toBeInTheDocument();
     expect(screen.getByText(/epoch block/i)).toBeInTheDocument();
   });
 });

--- a/src/components/ReportGeneratedPoolDetail/PoolTabs/DeregsitrationTab.tsx
+++ b/src/components/ReportGeneratedPoolDetail/PoolTabs/DeregsitrationTab.tsx
@@ -53,9 +53,9 @@ const DeregsitrationTab = () => {
         return (
           <TableSubTitle>
             <Box display="flex" mt={1} alignItems="center" lineHeight="1">
-              <AdaValue color={theme.palette.secondary.light} value={data.poolHold} gap="3px" fontSize="12px" />
+              <AdaValue color={theme.palette.secondary.main} value={data.poolHold} gap="3px" fontSize="12px" />
               <Box mx="3px">/</Box>
-              <AdaValue color={theme.palette.secondary.light} value={data.fee} gap="3px" fontSize="12px" />
+              <AdaValue color={theme.palette.secondary.main} value={data.fee} gap="3px" fontSize="12px" />
             </Box>
           </TableSubTitle>
         );

--- a/src/components/ReportGeneratedPoolDetail/PoolTabs/PoolSizeTab.tsx
+++ b/src/components/ReportGeneratedPoolDetail/PoolTabs/PoolSizeTab.tsx
@@ -30,7 +30,7 @@ const PoolSizeTab = () => {
       render: (r) => (
         <Box display="flex" alignItems="center">
           <TextAmountReward>{formatADAFull(r.size || 0)}</TextAmountReward>
-          <ADAicon />
+          <ADAicon data-testid="poolsize-ada-icon" />
         </Box>
       )
     },

--- a/src/components/ReportGeneratedPoolDetail/PoolTabs/ReportDetailPoolTabs.test.tsx
+++ b/src/components/ReportGeneratedPoolDetail/PoolTabs/ReportDetailPoolTabs.test.tsx
@@ -118,7 +118,7 @@ describe("PoolSizeTab", () => {
     render(<PoolSizeTab />);
     expect(screen.getByRole("link", { name: mockData.epoch.toString() })).toBeInTheDocument();
     expect(screen.getByText(formatADAFull(mockData.size))).toBeInTheDocument();
-    expect(screen.getByText(/aicongreen\.svg/i)).toBeInTheDocument();
+    expect(screen.getByTestId("poolsize-ada-icon")).toBeInTheDocument();
   });
 
   it("should component goto epoch page", () => {

--- a/src/components/StakeDetail/StakeTab/Tabs/DelegationHistoryTab.tsx
+++ b/src/components/StakeDetail/StakeTab/Tabs/DelegationHistoryTab.tsx
@@ -91,7 +91,7 @@ const DelegationHistoryTab = ({ isMobile = false }) => {
       pagination={{
         ...pageInfo,
         total: fetchData.total,
-        onChange: (page, size) => history.replace({ search: stringify({ page, size }) })
+        onChange: (page, size) => history.replace({ search: stringify({ page, size }) }, history.location.state)
       }}
       onClickRow={(e, r: DelegationHistory) => history.push(details.delegation(r.poolId))}
     />

--- a/src/components/StakeDetail/StakeTab/Tabs/InstantaneousTab.tsx
+++ b/src/components/StakeDetail/StakeTab/Tabs/InstantaneousTab.tsx
@@ -74,7 +74,7 @@ const InstantaneousTab = () => {
       pagination={{
         ...pageInfo,
         total: fetchData.total,
-        onChange: (page, size) => history.replace({ search: stringify({ page, size }) })
+        onChange: (page, size) => history.replace({ search: stringify({ page, size }) }, history.location.state)
       }}
     />
   );

--- a/src/components/StakeDetail/StakeTab/Tabs/StakeHistoryTab.tsx
+++ b/src/components/StakeDetail/StakeTab/Tabs/StakeHistoryTab.tsx
@@ -77,7 +77,7 @@ const StakeHistoryTab = ({ isMobile = false }) => {
       pagination={{
         ...pageInfo,
         total: fetchData.total,
-        onChange: (page, size) => history.replace({ search: stringify({ page, size }) })
+        onChange: (page, size) => history.replace({ search: stringify({ page, size }) }, history.location.state)
       }}
     />
   );

--- a/src/components/StakeDetail/StakeTab/Tabs/TransactionTab.tsx
+++ b/src/components/StakeDetail/StakeTab/Tabs/TransactionTab.tsx
@@ -187,7 +187,7 @@ const TransactionListFull: React.FC<TransactionListFullProps> = ({
           pagination={{
             ...pageInfo,
             total: fetchData.total,
-            onChange: (page, size) => history.replace({ search: stringify({ page, size }) })
+            onChange: (page, size) => history.replace({ search: stringify({ page, size }) }, history.location.state)
           }}
           onClickRow={onClickRow}
           selected={selected}

--- a/src/components/StakeDetail/StakeTab/Tabs/WithdrawalHistoryTab.tsx
+++ b/src/components/StakeDetail/StakeTab/Tabs/WithdrawalHistoryTab.tsx
@@ -74,7 +74,7 @@ const WithdrawalHistoryTab = () => {
       pagination={{
         ...pageInfo,
         total: fetchData.total,
-        onChange: (page, size) => history.replace({ search: stringify({ page, size }) })
+        onChange: (page, size) => history.replace({ search: stringify({ page, size }) }, history.location.state)
       }}
     />
   );

--- a/src/components/StakeDetail/StakeTab/index.tsx
+++ b/src/components/StakeDetail/StakeTab/index.tsx
@@ -27,7 +27,7 @@ const StakeTab = () => {
   const { isMobile } = useScreen();
 
   const handleChange = (event: React.SyntheticEvent, tab: TabStakeDetail) => {
-    history.replace({ pathname: details.stake(stakeId || "", tab) });
+    history.replace({ pathname: details.stake(stakeId || "", tab) }, history.location.state);
   };
 
   const tabs: {

--- a/src/components/commons/ADAValue/index.tsx
+++ b/src/components/commons/ADAValue/index.tsx
@@ -8,9 +8,9 @@ interface IAdaValue extends BoxProps {
   value: number | string;
 }
 
-export const AdaValue = ({ value }: IAdaValue) => {
+export const AdaValue = ({ value, ...props }: IAdaValue) => {
   return (
-    <Box component="span">
+    <Box component="span" {...props}>
       {formatADAFull(value)}&nbsp;
       <ADAicon />
     </Box>

--- a/src/components/commons/HoldBox/HoldBox.test.tsx
+++ b/src/components/commons/HoldBox/HoldBox.test.tsx
@@ -9,6 +9,6 @@ describe("HoldBox component", () => {
     render(<HoldBox txHash={mockHash} value={100000000} />);
     expect(screen.getByText(/100/i)).toBeInTheDocument();
     expect(screen.getByText(/buttonlist\.svg/i)).toBeInTheDocument();
-    expect(screen.getByText(/ada-logo\.svg/i)).toBeInTheDocument();
+    expect(screen.getByTestId("holdbox-ada-icon")).toBeInTheDocument();
   });
 });

--- a/src/components/commons/HoldBox/index.tsx
+++ b/src/components/commons/HoldBox/index.tsx
@@ -102,7 +102,7 @@ export const HoldBox = forwardRef<HTMLElement, Props>((props, feeRef) => {
         <HoldContainer {...boxProps} ref={feeRef}>
           <Value>
             <HolderValueLabel>{formatADAFull(value || 0, roundingNumber)}</HolderValueLabel>
-            <ADAicon width={12} />
+            <ADAicon width={12} data-testid="holdbox-ada-icon" />
           </Value>
           {children}
           <Button

--- a/src/pages/DelegationDetail/index.tsx
+++ b/src/pages/DelegationDetail/index.tsx
@@ -40,7 +40,7 @@ const DelegationDetail: React.FC = () => {
   };
 
   const setQuery = (query: any) => {
-    history.replace({ search: stringify(query) });
+    history.replace({ search: stringify(query) }, state);
   };
 
   const status = useFetch<ListTabResponseSPO>(API.SPO_LIFECYCLE.TABS(poolId));
@@ -49,13 +49,14 @@ const DelegationDetail: React.FC = () => {
     `${API.DELEGATION.POOL_DETAIL_HEADER}/${poolId}`
   );
 
-  const {
-    data: dataTable,
-    loading: loadingTable,
-    total,
-    initialized: initalTable
-  } = useFetchList<DelegationEpoch | StakingDelegators>(
-    `${API.DELEGATION.POOL_DETAIL}-${tab}?poolView=${poolId}&page=${query.page ? +query.page - 1 : 0}&size=${
+  const fetchDataEpochs = useFetchList<DelegationEpoch>(
+    `${API.DELEGATION.POOL_DETAIL("epochs")}?poolView=${poolId}&page=${query.page ? +query.page - 1 : 0}&size=${
+      query.size || 50
+    }`
+  );
+
+  const fetchDataDelegators = useFetchList<StakingDelegators>(
+    `${API.DELEGATION.POOL_DETAIL("delegators")}?poolView=${poolId}&page=${query.page ? +query.page - 1 : 0}&size=${
       query.size || 50
     }`
   );
@@ -86,13 +87,7 @@ const DelegationDetail: React.FC = () => {
       key: "epochs",
       component: (
         <div ref={tableRef}>
-          <DelegationEpochList
-            data={dataTable as DelegationEpoch[]}
-            loading={loadingTable}
-            initialized={initalTable}
-            total={total}
-            scrollEffect={scrollEffect}
-          />
+          <DelegationEpochList {...fetchDataEpochs} scrollEffect={scrollEffect} />
         </div>
       )
     },
@@ -102,13 +97,7 @@ const DelegationDetail: React.FC = () => {
       key: "delegators",
       component: (
         <div ref={tableRef}>
-          <DelegationStakingDelegatorsList
-            data={dataTable as StakingDelegators[]}
-            loading={loadingTable}
-            initialized={initalTable}
-            total={total}
-            scrollEffect={scrollEffect}
-          />
+          <DelegationStakingDelegatorsList {...fetchDataDelegators} scrollEffect={scrollEffect} />
         </div>
       )
     }


### PR DESCRIPTION
## Description

 - Fix: issue menu active invalid when change tab in stake and pool detail page (Auto change menu when switch tab) => Keep menu when switch tab.
 - Fix: Unit test failed.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: no Jira ticket

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/fce12397-e25f-4835-9c2d-37dbe8b368ed

##### _After_

https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/ab9576a4-199c-40dc-a079-b49b69b8337f