### PR TITLE
fix: MET-1347 finding 3 add eye icon to Saved Reports table

### DIFF
--- a/src/components/PoolLifecycle/index.tsx
+++ b/src/components/PoolLifecycle/index.tsx
@@ -168,6 +168,7 @@ const PoolLifecycle: React.FC<IPoolLifecycleProps> = ({ onSort, fetchData, pagin
           total: fetchData.total,
           onChange: (page, size) => onPagination?.({ page: page - 1, size })
         }}
+        showTabView
       />
     </Box>
   );

--- a/src/components/StakekeySummary/index.tsx
+++ b/src/components/StakekeySummary/index.tsx
@@ -168,6 +168,7 @@ const StakekeySummary: React.FC<IStakekeySummaryProps> = ({ fetchData, onSort, p
           total: fetchData.total,
           onChange: (page, size) => onPagination?.({ page: page - 1, size })
         }}
+        showTabView
       />
     </Box>
   );


### PR DESCRIPTION
## Description

fix: MET-1347 finding 3 add eye icon to Saved Reports table

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1347](https://cardanofoundation.atlassian.net/browse/MET-1347)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|--------|
| ![Screenshot_93](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/6f48c3ef-6da9-4059-ae51-6e117b3f7d9b) | ![Screenshot_92](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/493388d7-d49e-441e-843e-2497496b53c2) |

#### Safari

Same Chrome

#### Responsive



| Before | After |
|--------|--------|
| ![Screenshot_94](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/754b41a8-c6f0-4f04-b873-84c5a652bfde) | ![Screenshot_95](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/f61695f0-549c-46d2-b1ee-c959b34b74b7) |

[MET-1347]: https://cardanofoundation.atlassian.net/browse/MET-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ