### PR TITLE
fix: Addresses-with-no-stake-address(MET-1445)

### DIFF
--- a/src/components/commons/NoStakeAddress/index.tsx
+++ b/src/components/commons/NoStakeAddress/index.tsx
@@ -7,7 +7,7 @@ import { Image, Message, NoRecordContainer } from "./styles";
 const NoStakeAddress = () => (
   <NoRecordContainer component={Container}>
     <Image src={NoRecordsIcon} alt="empty icon" />
-    <Message>This address has no stake key associated to it or is not delegating to any address.</Message>
+    <Message>This address has no stake key associated to it.</Message>
   </NoRecordContainer>
 );
 


### PR DESCRIPTION
## Description

 This address has no stake key associated to it or is not delegating to any address instead of this page with “no records“. 

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1445](https://cardanofoundation.atlassian.net/browse/MET-1445)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
<img width="823" alt="01" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/328e5a81-4ff0-447e-a234-5e6cceb28c1d">


##### _After_

[comment]: <> (Add screenshots)

<img width="818" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/132533358/5510116f-eae7-449c-9386-131db740a752">




[MET-1445]: https://cardanofoundation.atlassian.net/browse/MET-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ