### PR TITLE
fix: MET-935 add websocket to get latest events

### DIFF
--- a/src/components/SystemLoader/index.tsx
+++ b/src/components/SystemLoader/index.tsx
@@ -41,7 +41,7 @@ export const SystemLoader = () => {
   }, [usdMarket]);
 
   useEffect(() => {
-    if (btcMarket?.[0]) setUsdMarket(btcMarket[0]);
+    if (btcMarket?.[0]) setBtcMarket(btcMarket[0]);
   }, [btcMarket]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

fix: MET-935 add websocket to get latest events.
 - Change from use interval to socket.
 - Add refresh in the analytics chart (5 chart).
 - Add new env  REACT_APP_WS_URL

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-935](https://cardanofoundation.atlassian.net/browse/MET-935)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-935]: https://cardanofoundation.atlassian.net/browse/MET-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ