### PR TITLE
fix: MET-1445 finding 1 edit ui no stake key in address detail header

### DIFF
--- a/src/components/commons/NoStakeAddress/index.tsx
+++ b/src/components/commons/NoStakeAddress/index.tsx
@@ -7,7 +7,7 @@ import { Image, Message, NoRecordContainer } from "./styles";
 const NoStakeAddress = () => (
   <NoRecordContainer component={Container}>
     <Image src={NoRecordsIcon} alt="empty icon" />
-    <Message>This address has no stake key associated to it.</Message>
+    <Message>No stake key associated.</Message>
   </NoRecordContainer>
 );
 


### PR DESCRIPTION
## Description

Change text when have no stake key associate with the address.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1445](https://cardanofoundation.atlassian.net/browse/MET-1445)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-1445]: https://cardanofoundation.atlassian.net/browse/MET-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ