### PR TITLE
fix: MET-1587 resize ada icon in live stake

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -22,6 +22,7 @@ import { formatADA, formatADAFull, formatDateTimeLocal, numberWithCommas } from 
 import CustomTooltip from "src/components/commons/CustomTooltip";
 import RateWithIcon from "src/components/commons/RateWithIcon";
 import { RootState } from "src/stores/types";
+import ADAicon from "src/components/commons/ADAIcon";
 
 import {
   AdaPrice,
@@ -35,7 +36,6 @@ import {
   Progress,
   ProgressPending,
   StatisticContainer,
-  StyledAdaLogoIcon,
   TextPending,
   TimeDuration,
   Title,
@@ -234,7 +234,9 @@ const HomeStatistic = () => {
                       src={LiveStakeIcon}
                       alt="Total ADA Stake"
                     />
-                    <Name data-testid="live-stake-box-title">{t("glossary.liveStake")}</Name>
+                    <Name data-testid="live-stake-box-title">
+                      {t("glossary.liveStake")} (<ADAicon />)
+                    </Name>
                   </Box>
                 </Box>
                 <Box>
@@ -261,7 +263,8 @@ const HomeStatistic = () => {
                 </Box>
                 <Box>
                   <Box color={({ palette }) => palette.secondary.light}>
-                    {t("glossary.activeStake")} <StyledAdaLogoIcon />:{" "}
+                    {t("glossary.activeStake")} <ADAicon width={10} />
+                    :&nbsp;
                     <CustomTooltip title={formatADAFull(activeStake)}>
                       <span data-testid="active-stake-value">{formatADA(activeStake)}</span>
                     </CustomTooltip>
@@ -269,7 +272,8 @@ const HomeStatistic = () => {
                   <Box fontSize={"12px"} color={({ palette }) => palette.secondary.light}>
                     <CustomTooltip title={t("glossary.offTheMaxSupply")}>
                       <span>
-                        {t("glossary.circulatingSupply")} <StyledAdaLogoIcon />:{" "}
+                        {t("glossary.circulatingSupply")} <ADAicon width={8} />
+                        :&nbsp;
                       </span>
                     </CustomTooltip>
                     <CustomTooltip title={formatADAFull(currentEpoch?.circulatingSupply || 0)}>


### PR DESCRIPTION
## Description

fix: MET-1587 resize ada icon in live stake
## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1587](https://cardanofoundation.atlassian.net/browse/MET-1031)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

Before:
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/366d2573-1e4d-472c-8d0b-2d0f65c12301)

After:

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/50062a04-7fce-4d1b-8dc9-2576d298c260)


[MET-1587]: https://cardanofoundation.atlassian.net/browse/MET-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ