### PR TITLE
fix: MET-1531 missing genesis in block detail

### DIFF
--- a/src/components/BlockDetail/BlockOverview/index.tsx
+++ b/src/components/BlockDetail/BlockOverview/index.tsx
@@ -113,7 +113,7 @@ const BlockOverview: React.FC<BlockOverviewProps> = ({ data, loading, lastUpdate
       ),
       value: (
         <>
-          {data?.epochSlotNo}
+          {data?.epochNo}
           <Subtext>/{isNil(data?.epochSlotNo) ? null : MAX_SLOT_EPOCH}</Subtext>
         </>
       )

--- a/src/components/EpochDetail/EpochBlockList/index.tsx
+++ b/src/components/EpochDetail/EpochBlockList/index.tsx
@@ -6,7 +6,13 @@ import { useTranslation } from "react-i18next";
 
 import Card from "src/components/commons/Card";
 import Table, { Column } from "src/components/commons/Table";
-import { formatADAFull, formatDateTimeLocal, getPageInfo, getShortHash } from "src/commons/utils/helper";
+import {
+  formatADAFull,
+  formatDateTimeLocal,
+  formatNameBlockNo,
+  getPageInfo,
+  getShortHash
+} from "src/commons/utils/helper";
 import { details } from "src/commons/routers";
 import useFetchList from "src/commons/hooks/useFetchList";
 import { API } from "src/commons/utils/api";
@@ -38,9 +44,16 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
       title: t("glossary.block"),
       key: "block",
       minWidth: "100px",
-      render: (r) => (
-        <StyledLink to={details.block(r.blockNo || r.hash)}>{r.blockNo || getShortHash(r.hash || "")}</StyledLink>
-      )
+      render: (r) => {
+        const { blockName, tooltip } = formatNameBlockNo(r.blockNo, r.epochNo);
+        return (
+          <StyledLink to={details.block(r.blockNo || r.hash)}>
+            <CustomTooltip title={tooltip}>
+              <span>{blockName}</span>
+            </CustomTooltip>
+          </StyledLink>
+        );
+      }
     },
     {
       title: t("glossary.blockID"),
@@ -60,7 +73,7 @@ const EpochBlockList: React.FC<IEpochBlockList> = ({ epochId }) => {
         <>
           <EpochNo>{r.slotNo}</EpochNo>
           <Box color={({ palette }) => palette.secondary.light}>
-            {r.epochNo}/{r.epochSlotNo || 0}
+            {r.epochNo}/{r.epochSlotNo}
           </Box>
         </>
       )


### PR DESCRIPTION
## Description

fix: MET-1531 missing genesis in block detail
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [MET-1531](https://cardanofoundation.atlassian.net/browse/MET-1031)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

BEFORE
<img width="852" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/204eaadc-94ad-4687-b89f-6087a0c34938">
<img width="286" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/b8779ccc-b561-4fde-858a-ef29925d360e">

AFTER
<img width="261" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/a83260cf-d05f-45fd-bc24-a2baf04d018e">
<img width="527" alt="image" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/92282849/0b7a2a6d-9f24-44e4-8ca5-75e387683d70">


[MET-1531]: https://cardanofoundation.atlassian.net/browse/MET-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ