### PR TITLE
fix: MET-935 add websocket to get latest events fix conflict sota_testing

### DIFF
--- a/env.global.tmp.js
+++ b/env.global.tmp.js
@@ -3,6 +3,7 @@ window.env = {};
 window.env.REACT_APP_VERSION = `$REACT_APP_VERSION`;
 window.env.REACT_APP_NETWORK = `$REACT_APP_NETWORK`;
 window.env.REACT_APP_API_URL = `$REACT_APP_API_URL`;
+window.env.REACT_APP_WS_URL = `$REACT_APP_WS_URL`;
 
 window.env.REACT_APP_AUTH_API_URL = `$REACT_APP_AUTH_API_URL`;
 

--- a/src/components/AddressTransactionList/index.tsx
+++ b/src/components/AddressTransactionList/index.tsx
@@ -1,8 +1,8 @@
 import { Box, useTheme } from "@mui/material";
 import { stringify } from "qs";
 import { useHistory, useLocation } from "react-router-dom";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import receiveImg from "src/commons/resources/images/receiveImg.svg";
 import sendImg from "src/commons/resources/images/sendImg.svg";

--- a/src/components/SystemLoader/index.tsx
+++ b/src/components/SystemLoader/index.tsx
@@ -44,10 +44,10 @@ export const SystemLoader = () => {
       } = currentEpoch;
       const interval = setInterval(() => {
         const newSlot = slot + Math.floor((Date.now() - currentTime.current) / 1000);
-        const isCrawlerStop = newSlot - MAX_SLOT_EPOCH > 1000;
-        const newNo = newSlot >= MAX_SLOT_EPOCH && !isCrawlerStop ? no + 1 : no;
+        const isCrawlerStop = newSlot - totalSlot > 100;
+        const newNo = newSlot >= totalSlot && !isCrawlerStop ? no + 1 : no;
         setStoreCurrentEpoch({
-          slot: newSlot % MAX_SLOT_EPOCH,
+          slot: newSlot % totalSlot,
           no: newNo,
           totalSlot,
           account,

--- a/src/components/TokenDetail/TokenTableData/TokenMinting.tsx
+++ b/src/components/TokenDetail/TokenTableData/TokenMinting.tsx
@@ -1,8 +1,8 @@
 import { stringify } from "qs";
 import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import useFetchList from "src/commons/hooks/useFetchList";
 import { details } from "src/commons/routers";

--- a/src/components/TokenDetail/TokenTableData/TokenTopHolder.tsx
+++ b/src/components/TokenDetail/TokenTableData/TokenTopHolder.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { stringify } from "qs";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import useFetchList from "src/commons/hooks/useFetchList";
 import { details } from "src/commons/routers";

--- a/src/components/TokenDetail/TokenTableData/TokenTransaction.tsx
+++ b/src/components/TokenDetail/TokenTableData/TokenTransaction.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { Box } from "@mui/material";
 import { stringify } from "qs";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import { OverviewMetadataTokenContext } from "src/pages/TokenDetail";
 import useFetchList from "src/commons/hooks/useFetchList";

--- a/src/components/commons/DetailView/DetailViewEpoch.tsx
+++ b/src/components/commons/DetailView/DetailViewEpoch.tsx
@@ -55,8 +55,8 @@ type DetailViewEpochProps = {
 };
 
 const DetailViewEpoch: React.FC<DetailViewEpochProps> = ({ epochNo, handleClose, callback }) => {
-  const { t } = useTranslation();
   const { currentEpoch, blockNo } = useSelector(({ system }: RootState) => system);
+  const { t } = useTranslation();
   const [key, setKey] = useState(0);
 
   const { data, lastUpdated } = useFetch<IDataEpoch>(

--- a/src/components/commons/FormNowMessage/index.tsx
+++ b/src/components/commons/FormNowMessage/index.tsx
@@ -12,14 +12,14 @@ const FormNowMessage = ({ time }: Props) => {
 
   useEffect(() => {
     if (time) {
-      setMessage(`Last updated ${moment(time).fromNow()}`);
+      setMessage(`${t("common.lastUpdated")} ${moment(time).fromNow()}`);
       const interval = setInterval(() => {
-        setMessage(`${t("common.lastUpdated")}  ${moment(time).fromNow()}`);
+        setMessage(`${t("common.lastUpdated")} ${moment(time).fromNow()}`);
       }, 1000);
 
       return () => clearInterval(interval);
     }
-  }, [time]);
+  }, [time, t]);
 
   return <>{message}</>;
 };

--- a/src/pages/DelegationDetail/index.tsx
+++ b/src/pages/DelegationDetail/index.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useRef } from "react";
 import { useHistory, useLocation, useParams } from "react-router-dom";
 import { parse, stringify } from "qs";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
 
 import useFetch from "src/commons/hooks/useFetch";
 import DelegationDetailInfo from "src/components/DelegationDetail/DelegationDetailInfo";

--- a/src/pages/Epoch/index.tsx
+++ b/src/pages/Epoch/index.tsx
@@ -29,14 +29,15 @@ const Epoch: React.FC = () => {
   const pageInfo = getPageInfo(search);
   const [sort, setSort] = useState<string>("");
   const [key, setKey] = useState(0);
+  const fetchData = useFetchList<IDataEpoch>(API.EPOCH.LIST, { ...pageInfo, sort }, false, epochNo);
+  const fetchDataLatestEpoch = useFetchList<IDataEpoch>(API.EPOCH.LIST, { page: 0, size: 1 }, false, key);
+
   const EPOCH_STATUS_MAPPING = {
     [EPOCH_STATUS.FINISHED]: t("common.epoch.finished"),
     [EPOCH_STATUS.IN_PROGRESS]: t("common.epoch.inProgress"),
     [EPOCH_STATUS.REWARDING]: t("common.epoch.rewarding"),
     [EPOCH_STATUS.SYNCING]: t("common.epoch.cyncing")
   };
-  const fetchData = useFetchList<IDataEpoch>(API.EPOCH.LIST, { ...pageInfo, sort }, false, epochNo);
-  const fetchDataLatestEpoch = useFetchList<IDataEpoch>(API.EPOCH.LIST, { page: 0, size: 1 }, false, key);
 
   const mainRef = useRef(document.querySelector("#main"));
   const columns: Column<IDataEpoch>[] = [


### PR DESCRIPTION
## Description

Fix: MET-935 add websocket to get latest events
Update ENV: please add new ENV ```REACT_APP_WS_URL``` for use this feature

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-935](https://cardanofoundation.atlassian.net/browse/MET-935)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---


| Before | After |
|--------|--------|
| Call api each 20s, use setInterval | Call api each block, use websocket |
| ![Screenshot_114](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/d6dcb096-4bb2-4b6f-a9c6-b62803ba4531) | ![Screenshot_113](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/24c2fd22-7902-4b3b-b52f-7cc1ccf8e68c) |


[MET-935]: https://cardanofoundation.atlassian.net/browse/MET-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ