### PR TITLE
fix: MET-935 add websocket to get latest events set timeout crawler stop

### DIFF
--- a/src/components/SystemLoader/index.tsx
+++ b/src/components/SystemLoader/index.tsx
@@ -42,9 +42,10 @@ export const SystemLoader = () => {
         circulatingSupply,
         blkCount
       } = currentEpoch;
+      const TIME_OUT_CRAWLER_STOP = 100;
       const interval = setInterval(() => {
         const newSlot = slot + Math.floor((Date.now() - currentTime.current) / 1000);
-        const isCrawlerStop = newSlot - totalSlot > 100;
+        const isCrawlerStop = newSlot - totalSlot > TIME_OUT_CRAWLER_STOP;
         const newNo = newSlot >= totalSlot && !isCrawlerStop ? no + 1 : no;
         setStoreCurrentEpoch({
           slot: newSlot % totalSlot,


### PR DESCRIPTION
## Description

Add variable TIME_OUT_CRAWLER_STOP for checking crawler stop

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)