### PR TITLE
fix: MET-1587 comment fix dashboard statistic break line text

### DIFF
--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -45,19 +45,20 @@ import {
   TextPending,
   TimeDuration,
   Title,
+  VerticalContent,
   WrapCardContent,
   WrapGrid
 } from "./style";
 
 const SkeletonBox = () => (
   <Item>
-    <Content>
+    <Box>
       <ItemSkeleton width="50%" />
       <ItemSkeleton width="30%" />
       <ItemSkeleton />
       <ItemSkeleton width="50%" />
       <ItemSkeleton width="80%" />
-    </Content>
+    </Box>
   </Item>
 );
 
@@ -125,12 +126,12 @@ const HomeStatistic = () => {
                   <Name data-testid="ada-price-box-title">{t("stats.adaPrice")}</Name>
                 </Box>
                 <Box display={"flex"} alignItems={"center"}>
-                  <ItemIcon src={sign > 0 ? HomeUpIcon : HomeDownIcon} alt="Home up icon" />
-                  <Box ml={2}>
+                  <img src={sign > 0 ? HomeUpIcon : HomeDownIcon} alt="Home up icon" width={30} height={30} />
+                  <Box ml={1}>
                     <Title data-testid="ada-current-price">${usdMarket.current_price}</Title>
                   </Box>
                 </Box>
-                <Content display={"flex"} justifyContent={"space-between"} alignItems={"center"} flexWrap={"wrap"}>
+                <Content gap="5px 15px">
                   <RateWithIcon
                     data-testid="ada-twenty-four-hr-price-change"
                     value={usdMarket.price_change_percentage_24h}
@@ -138,7 +139,7 @@ const HomeStatistic = () => {
                   />
                   <AdaPrice data-testid="ada-price-in-btc">{btcMarket[0]?.current_price} BTC</AdaPrice>
                 </Content>
-                <Content display={"flex"} justifyContent={"space-between"} alignItems={"center"} flexWrap={"wrap"}>
+                <Content>
                   <TimeDuration data-testid="last-update-ada-price">
                     {t("info.lastUpdatedTime", { time: moment(usdMarket.last_updated).fromNow() })}
                   </TimeDuration>
@@ -176,7 +177,7 @@ const HomeStatistic = () => {
         {currentEpoch ? (
           <Box component={LinkDom} display={"contents"} to={details.epoch(currentEpoch?.no)}>
             <Item data-testid="current-epoch-box">
-              <Content display={"flex"} flexDirection={"column"} justifyContent={"space-between"} height={"100%"}>
+              <VerticalContent>
                 <Box display={"flex"} alignItems={"center"} height={"40px"}>
                   <ItemIcon
                     style={{ top: isGalaxyFoldSmall ? 10 : 15, right: isGalaxyFoldSmall ? 10 : 20 }}
@@ -189,7 +190,7 @@ const HomeStatistic = () => {
                   </Name>
                 </Box>
                 <Box>
-                  <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"} flexWrap={"wrap"}>
+                  <Content>
                     <Title data-testid="current-epoch-number">{numberWithCommas(currentEpoch?.no)}</Title>
                     <Box color={({ palette }) => palette.secondary.light}>
                       {t("common.slot")}:{" "}
@@ -198,7 +199,7 @@ const HomeStatistic = () => {
                         : numberWithCommas(MAX_SLOT_EPOCH)}
                       / {numberWithCommas(MAX_SLOT_EPOCH)}
                     </Box>
-                  </Box>
+                  </Content>
                   <Progress>
                     <CustomTooltip title={epochActiveText}>
                       <ProcessActive data-testid="current-epoch-progress-active" rate={+progress || 0}>
@@ -224,7 +225,7 @@ const HomeStatistic = () => {
                     {t("glossary.endTimestamp")}: {formatDateTimeLocal(currentEpoch?.endTime)}
                   </Box>
                 </Box>
-              </Content>
+              </VerticalContent>
             </Item>
           </Box>
         ) : (
@@ -235,7 +236,7 @@ const HomeStatistic = () => {
         {data && usdMarket ? (
           <Box component={LinkDom} display={"contents"} to={routers.DELEGATION_POOLS}>
             <Item data-testid="live-stake-box">
-              <Content display={"flex"} flexDirection={"column"} justifyContent={"space-between"} height={"100%"}>
+              <VerticalContent>
                 <Box>
                   <Box display={"flex"} alignItems={"center"} height={"40px"}>
                     <ItemIcon
@@ -273,7 +274,7 @@ const HomeStatistic = () => {
                 </Box>
                 <Box>
                   <Box color={({ palette }) => palette.secondary.light}>
-                    {t("glossary.activeStake")} (<ADAicon width={10} />) :&nbsp;
+                    {t("glossary.activeStake")} (<ADAicon width={10} />){": "}
                     <CustomTooltip title={formatADAFull(activeStake)}>
                       <span data-testid="active-stake-value">{formatADA(activeStake)}</span>
                     </CustomTooltip>
@@ -281,11 +282,11 @@ const HomeStatistic = () => {
                   <Box fontSize={"12px"} color={({ palette }) => palette.secondary.light}>
                     <CustomTooltip title={t("glossary.offTheMaxSupply")}>
                       <span>
-                        {t("glossary.circulatingSupply")} (<ADAicon width={8} />) :&nbsp;
+                        {t("glossary.circulatingSupply")} (<ADAicon width={8} />){": "}
                       </span>
                     </CustomTooltip>
                     <CustomTooltip title={formatADAFull(currentEpoch?.circulatingSupply || 0)}>
-                      <span data-testid="circulating-supply-value">{formatADA(circulatingSupply.toString())}</span>
+                      <span data-testid="circulating-supply-value">{formatADA(circulatingSupply.toString())} </span>
                     </CustomTooltip>
                     <CustomTooltip title={`${circulatingRate.toFixed(5)}%`}>
                       <span data-testid="circulating-supply-percentage">
@@ -294,7 +295,7 @@ const HomeStatistic = () => {
                     </CustomTooltip>
                   </Box>
                 </Box>
-              </Content>
+              </VerticalContent>
             </Item>
           </Box>
         ) : (

--- a/src/components/Home/Statistic/style.ts
+++ b/src/components/Home/Statistic/style.ts
@@ -58,6 +58,16 @@ export const ItemIcon = styled("img")`
 
 export const Content = styled(Box)`
   overflow: hidden;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+export const VerticalContent = styled(Content)`
+  flex-direction: column;
+  align-items: unset;
+  height: 100%;
 `;
 
 export const Name = styled("h4")`
@@ -102,21 +112,14 @@ export const SmallValue = styled("small")`
 
 export const AdaPrice = styled("small")`
   color: ${(props) => props.theme.palette.secondary.light};
-  white-space: nowrap;
-  margin-left: 15px;
-  ${({ theme }) => theme.breakpoints.down("sm")} {
-    margin-left: 0px;
-  }
 `;
+
 export const TimeDuration = styled("small")<{ marginTop?: string }>`
   color: ${(props) => props.theme.palette.secondary.light};
   margin-top: ${(props) => props.marginTop || 0};
-  white-space: nowrap;
   display: block;
-  ${({ theme }) => theme.breakpoints.down("sm")} {
-    white-space: unset;
-  }
 `;
+
 export const XSmall = styled("span")`
   font-size: var(--font-size-text-small);
   color: ${(props) => props.theme.palette.secondary.light};


### PR DESCRIPTION
## Description

Fix: MET-1587 comment fix dashboard statistic break line text.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1587](https://cardanofoundation.atlassian.net/browse/MET-1587)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

| Before | After |
|--------|--------|
| ![Screenshot_115](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/c1f792cd-15a9-43f8-8306-f518261c489f) | ![Screenshot_116](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/63cf5852-45c0-43a0-a882-95a419bd90c7) |


#### Responsive

| Before | After |
|--------|--------|
| ![Screenshot_117](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/14e14747-2094-478a-83f1-7e4e03656e2d) | ![Screenshot_118](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/cd7f177d-2833-4f2f-a9c2-cb6fdda0d743) |

[MET-1587]: https://cardanofoundation.atlassian.net/browse/MET-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ