### PR TITLE
fix: MET-1537 add sidebar's close button in mobile

### DIFF
--- a/src/components/commons/Layout/Sidebar/styles.ts
+++ b/src/components/commons/Layout/Sidebar/styles.ts
@@ -41,7 +41,7 @@ export const LogoLink = styled(Link)<{ open?: number }>`
   ${({ theme }) => theme.breakpoints.down("md")} {
     height: 44px;
     width: 155px;
-    margin-left: 16px;
+    margin-left: 20px;
     margin-bottom: 16px;
   }
 `;

--- a/src/components/commons/Layout/ToggleSidebar/index.tsx
+++ b/src/components/commons/Layout/ToggleSidebar/index.tsx
@@ -3,9 +3,10 @@ import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
 import { useSelector } from "react-redux";
 import { useTheme } from "@mui/material";
 
-import { RootState } from "src/stores/types";
+import { CloseLineIcon } from "src/commons/resources";
 
 import CustomTooltip from "../../CustomTooltip";
+import CustomIcon from "../../CustomIcon";
 import { ToggleMenu, ArrowCollapse } from "./styles";
 
 interface Props {
@@ -37,6 +38,15 @@ const ToggleSidebar: React.FC<Props> = ({ handleToggle }) => {
           ) : (
             <FaArrowRight color={theme.palette.secondary.light} data-testid="toggle-sidebar-arrow-right" />
           )}
+        </ArrowCollapse>
+        <ArrowCollapse mobile={1}>
+          <CustomIcon
+            icon={CloseLineIcon}
+            width={18}
+            height={18}
+            fill="currentColor"
+            color={(theme) => theme.palette.secondary.light}
+          />
         </ArrowCollapse>
       </ToggleMenu>
     </CustomTooltip>

--- a/src/components/commons/Layout/ToggleSidebar/styles.ts
+++ b/src/components/commons/Layout/ToggleSidebar/styles.ts
@@ -15,19 +15,26 @@ export const ToggleMenu = styled("button")`
   cursor: pointer;
   z-index: 1;
   ${({ theme }) => theme.breakpoints.down("md")} {
-    display: none;
+    top: 32px;
+    left: -42px;
+    padding: 5px;
   }
 `;
 
-export const ArrowCollapse = styled("span")`
+export const ArrowCollapse = styled("span")<{ mobile?: number }>`
   z-index: 100;
   width: 22px;
   height: 22px;
-  display: flex;
+  display: ${({ mobile }) => (mobile ? "none" : "flex")};
   justify-content: center;
   align-items: center;
   font-size: 14px;
   line-height: 14px;
   border-radius: 50%;
   background-color: ${(props) => props.theme.palette.primary[200]};
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    display: ${({ mobile }) => (mobile ? "flex" : "none")};
+    width: 30px;
+    height: 30px;
+  }
 `;

--- a/src/components/commons/Layout/styles.ts
+++ b/src/components/commons/Layout/styles.ts
@@ -125,6 +125,12 @@ export const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 
     "& > button": {
       visibility: "hidden"
     },
+    [theme.breakpoints.down("md")]: {
+      "& > button": {
+        visibility: "visible",
+        display: open ? "flex" : "none"
+      }
+    },
     "&:hover": {
       "& > button": {
         transitionDelay: "0s",


### PR DESCRIPTION
## Description

Fix: MET-1537 add side bar's close button in mobile.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1537](https://cardanofoundation.atlassian.net/browse/MET-1537)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Chrome

No change

#### Responsive
##### Tablet

| Before | After |
|--------|--------|
| ![Screenshot_119](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/56b36207-ce37-4eff-81a5-c5f4532912ea) | ![Screenshot_120](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/6935d387-5402-4855-b532-97be5aac89a3) |

##### Mobile
| Before | After |
|--------|--------|
| ![Screenshot_121](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/64f39702-3c9e-4b8b-9c72-acc234ee2a89) | ![Screenshot_122](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/ab7e76a1-a667-4fb1-8544-230781bf8cfc) |


[MET-1537]: https://cardanofoundation.atlassian.net/browse/MET-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ