### PR TITLE
fix: MET-1537 remove sidebar border in mobile

### DIFF
--- a/src/components/commons/Layout/ToggleSidebar/styles.ts
+++ b/src/components/commons/Layout/ToggleSidebar/styles.ts
@@ -16,7 +16,7 @@ export const ToggleMenu = styled("button")`
   z-index: 1;
   ${({ theme }) => theme.breakpoints.down("md")} {
     top: 32px;
-    left: -42px;
+    left: -40px;
     padding: 5px;
   }
 `;

--- a/src/components/commons/Layout/styles.ts
+++ b/src/components/commons/Layout/styles.ts
@@ -125,12 +125,6 @@ export const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 
     "& > button": {
       visibility: "hidden"
     },
-    [theme.breakpoints.down("md")]: {
-      "& > button": {
-        visibility: "visible",
-        display: open ? "flex" : "none"
-      }
-    },
     "&:hover": {
       "& > button": {
         transitionDelay: "0s",
@@ -140,6 +134,13 @@ export const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 
     "&:not(:hover)": {
       "& > button": {
         transitionDelay: "1s"
+      }
+    },
+    [theme.breakpoints.down("md")]: {
+      border: "none",
+      "& > button": {
+        visibility: "visible",
+        display: open ? "flex" : "none"
       }
     }
   }


### PR DESCRIPTION
## Description

Fix: MET-1537 remove sidebar border in mobile.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1537](https://cardanofoundation.atlassian.net/browse/MET-1537)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Chrome

No change

#### Responsive
##### Tablet

| Before | After |
|--------|--------|
| ![Screenshot_119](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/56b36207-ce37-4eff-81a5-c5f4532912ea) | ![Screenshot_124](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/74e2cee4-c742-4bcc-9983-886fdb92a07b) |

##### Mobile
| Before | After |
|--------|--------|
| ![Screenshot_121](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/64f39702-3c9e-4b8b-9c72-acc234ee2a89) | ![Screenshot_126](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/fbf71c5b-4de4-45e6-a613-a0a04e588ad0) |





[MET-1537]: https://cardanofoundation.atlassian.net/browse/MET-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ