### PR TITLE
fix: MET-1537 fix close button visibility

### DIFF
--- a/src/components/commons/Layout/styles.ts
+++ b/src/components/commons/Layout/styles.ts
@@ -125,6 +125,13 @@ export const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 
     "& > button": {
       visibility: "hidden"
     },
+    [theme.breakpoints.down("md")]: {
+      border: "none",
+      "& > button": {
+        visibility: "visible",
+        display: open ? "flex" : "none"
+      }
+    },
     "&:hover": {
       "& > button": {
         transitionDelay: "0s",
@@ -134,13 +141,6 @@ export const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 
     "&:not(:hover)": {
       "& > button": {
         transitionDelay: "1s"
-      }
-    },
-    [theme.breakpoints.down("md")]: {
-      border: "none",
-      "& > button": {
-        visibility: "visible",
-        display: open ? "flex" : "none"
       }
     }
   }


### PR DESCRIPTION
## Description

Fix: MET-935 add websocket to get latest events
Update ENV: please add new ENV ```REACT_APP_WS_URL``` for use this feature

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-935](https://cardanofoundation.atlassian.net/browse/MET-935)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---


| Before | After |
|--------|--------|
| Call api each 20s, use setInterval | Call api each block, use websocket |
| ![Screenshot_114](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/d6dcb096-4bb2-4b6f-a9c6-b62803ba4531) | ![Screenshot_113](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/24c2fd22-7902-4b3b-b52f-7cc1ccf8e68c) |


[MET-935]: https://cardanofoundation.atlassian.net/browse/MET-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ