### PR TITLE
fix: MET-1536 finding 1 keep search bar in home - test

### DIFF
--- a/src/components/commons/Layout/Header/index.tsx
+++ b/src/components/commons/Layout/Header/index.tsx
@@ -70,7 +70,7 @@ const Header: React.FC<RouteComponentProps> = (props) => {
               <Box component={"img"} src={CardanoBlueLogo} width={isMobile ? "80vw" : "auto"} sx={{ margin: "2rem" }} />
             </Box>
           </Title>
-          <HeaderSearchContainer>{!pathMatched && <HeaderSearch home={home} />}</HeaderSearchContainer>
+          <HeaderSearchContainer home={+home}>{!pathMatched && <HeaderSearch home={home} />}</HeaderSearchContainer>
         </HeaderMain>
         <HeaderTop data-testid="header-top" ref={refElement}>
           <HeaderLogoLink to="/" data-testid="header-logo">

--- a/src/components/commons/Layout/Header/styles.ts
+++ b/src/components/commons/Layout/Header/styles.ts
@@ -129,8 +129,8 @@ export const Toggle = styled("i")`
   }
 `;
 
-export const HeaderSearchContainer = styled(Box)`
+export const HeaderSearchContainer = styled(Box)<{ home?: number }>`
   ${(props) => props.theme.breakpoints.down("sm")} {
-    display: none;
+    display: ${({ home }) => (home ? "block" : "none")};
   }
 `;


### PR DESCRIPTION
## Description

Fix: MET-1536 finding 1 keep search bar in home

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-1536](https://cardanofoundation.atlassian.net/browse/MET-1536)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome

No change

#### Mobile


| Before | After |
|--------|--------|
| ![Screenshot_128](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/df6e175c-dc7f-4a49-a86e-1cf122c90d21) | ![Screenshot_127](https://github.com/cardano-foundation/cf-explorer-frontend/assets/102118956/eabce645-a568-4a6f-916b-a557f9070fe6) |

[MET-1536]: https://cardanofoundation.atlassian.net/browse/MET-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ