### PR TITLE
fix: MET-935 show message up to date data

### DIFF
--- a/src/components/Home/Statistic/Statistic.test.tsx
+++ b/src/components/Home/Statistic/Statistic.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, screen } from "@testing-library/react";
 import { useSelector } from "react-redux";
-import moment from "moment";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
 import "@testing-library/jest-dom/extend-expect";
@@ -81,9 +80,6 @@ describe("HomeStatistic", () => {
     render(<HomeStatistic />);
     expect(screen.getByTestId("market-cap-box-title")).toBeInTheDocument();
     expect(screen.getByTestId("market-cap-value")).toHaveTextContent(`$${numberWithCommas(mockUSDMarket.market_cap)}`);
-    expect(screen.getByTestId("last-update-market-cap")).toHaveTextContent(
-      `Last updated ${moment(mockUSDMarket.last_updated + "Z").fromNow()}`
-    );
   });
 
   it("renders Live Stake", async () => {

--- a/src/components/Home/Statistic/index.tsx
+++ b/src/components/Home/Statistic/index.tsx
@@ -110,6 +110,7 @@ const HomeStatistic = () => {
     last_updated: "",
     market_cap: 0
   });
+  const priceBTC = useRef<number>(0);
 
   useEffect(() => {
     if (Number(usdMarket?.market_cap) !== Number(marketcap.current.market_cap)) {
@@ -120,6 +121,17 @@ const HomeStatistic = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usdMarket?.market_cap]);
+
+  useEffect(() => {
+    if (Number(btcMarket?.current_price) !== priceBTC.current) {
+      priceBTC.current = Number(btcMarket?.current_price);
+      marketcap.current = {
+        ...marketcap.current,
+        last_updated: btcMarket?.last_updated || ""
+      };
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [btcMarket?.current_price, marketcap.current]);
 
   return (
     <StatisticContainer
@@ -164,7 +176,7 @@ const HomeStatistic = () => {
                 </Content>
                 <Content>
                   <TimeDuration data-testid="last-update-ada-price">
-                    <FormNowMessage time={usdMarket.last_updated + "Z"} />
+                    <FormNowMessage time={usdMarket.last_updated} />
                   </TimeDuration>
                 </Content>
               </WrapCardContent>
@@ -190,7 +202,7 @@ const HomeStatistic = () => {
                 <Title data-testid="market-cap-value">${numberWithCommas(usdMarket.market_cap)}</Title>
                 <Content>
                   <TimeDuration data-testid="last-update-market-cap">
-                    <FormNowMessage time={marketcap.current.last_updated + "Z"} />
+                    <FormNowMessage time={marketcap.current.last_updated} />
                   </TimeDuration>
                 </Content>
               </WrapCardContent>

--- a/src/components/SystemLoader/index.tsx
+++ b/src/components/SystemLoader/index.tsx
@@ -63,11 +63,11 @@ export const SystemLoader = () => {
   }, [currentEpoch]);
 
   useEffect(() => {
-    if (usdMarket?.[0]) setUsdMarket(usdMarket[0]);
+    if (usdMarket?.[0]) setUsdMarket({ ...usdMarket[0], last_updated: new Date().toString() });
   }, [usdMarket]);
 
   useEffect(() => {
-    if (btcMarket?.[0]) setBtcMarket(btcMarket[0]);
+    if (btcMarket?.[0]) setBtcMarket({ ...btcMarket[0], last_updated: new Date().toString() });
   }, [btcMarket]);
 
   useEffect(() => {
@@ -98,10 +98,10 @@ export const SystemLoader = () => {
               setCurrentEpoch(data.payload.epochSummary);
               break;
             case EVENT_TYPES.CURRENT_PRICE_USD:
-              if (data.payload[0]) setUsdMarket(data.payload[0]);
+              if (data.payload[0]) setUsdMarket({ ...data.payload[0], last_updated: new Date().toString() });
               break;
             case EVENT_TYPES.CURRENT_PRICE_BTC:
-              if (data.payload[0]) setBtcMarket(data.payload[0]);
+              if (data.payload[0]) setBtcMarket({ ...data.payload[0], last_updated: new Date().toString() });
               break;
             default:
               break;


### PR DESCRIPTION
## Description

fix: MET-935 show message up to date data
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [MET-935](https://cardanofoundation.atlassian.net/browse/MET-935)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-935]: https://cardanofoundation.atlassian.net/browse/MET-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ