### PR TITLE
fix: fix UI on smart contract detail and pool detail

### DIFF
--- a/src/components/DelegationDetail/DelegationDetailInfo/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailInfo/index.tsx
@@ -109,7 +109,7 @@ const DelegationDetailInfo: React.FC<IDelegationDetailInfo> = ({ data, loading, 
                 truncateCustom(poolId, 4, 4)
               ) : (
                 <TruncateSubTitleContainer>
-                  <DynamicEllipsisText value={poolId} sxFirstPart={{ maxWidth: "calc(100% - 180px)" }} />
+                  <DynamicEllipsisText value={poolId} sxFirstPart={{ maxWidth: "calc(100% - 145px)" }} />
                 </TruncateSubTitleContainer>
               )}
             </HeaderTitle>

--- a/src/components/TabularView/TabularOverview/index.tsx
+++ b/src/components/TabularView/TabularOverview/index.tsx
@@ -15,10 +15,11 @@ import {
   RewardsWithdrawDarkIcon
 } from "src/commons/resources/index";
 import { details } from "src/commons/routers";
-import { formatADAFull, getShortHash } from "src/commons/utils/helper";
+import { formatADAFull } from "src/commons/utils/helper";
 import ADATransferModal from "src/components/StakingLifeCycle/DelegatorLifecycle/ADATransferModal";
 import DelegatorDetailContext from "src/components/StakingLifeCycle/DelegatorLifecycle/DelegatorDetailContext";
 import CustomTooltip from "src/components/commons/CustomTooltip";
+import DynamicEllipsisText from "src/components/DynamicEllipsisText";
 
 import {
   BoxStyled,
@@ -83,7 +84,8 @@ const TabularOverview: React.FC = () => {
   const { totalStake, rewardAvailable, rewardWithdrawn, pool } = data ?? {};
   const { tickerName, poolName, poolId, iconUrl } = pool ?? {};
   const delegatingToValue =
-    tickerName || poolName ? `${tickerName && tickerName + " -"}  ${poolName && poolName}` : getShortHash(poolId || "");
+    tickerName || poolName ? `${tickerName && tickerName + " -"}  ${poolName && poolName}` : poolId || "";
+
   const delegatingTovalueTooltip =
     tickerName || poolName ? `${tickerName && tickerName + " -"}  ${poolName && poolName}` : poolId;
   const [open, setOpen] = useState(false);
@@ -133,7 +135,9 @@ const TabularOverview: React.FC = () => {
               <StyledBoxDelegating to={details.delegation(pool?.poolId)}>
                 <CardValueDelegating>
                   <CustomTooltip title={delegatingTovalueTooltip}>
-                    <BoxStyled>{delegatingToValue}</BoxStyled>
+                    <BoxStyled>
+                      <DynamicEllipsisText value={delegatingToValue} postfix={5} isNoLimitPixel={true} />
+                    </BoxStyled>
                   </CustomTooltip>
                 </CardValueDelegating>
               </StyledBoxDelegating>

--- a/src/components/share/styled.ts
+++ b/src/components/share/styled.ts
@@ -78,6 +78,11 @@ export const TruncateSubTitleContainer = styled(Box)(({ theme }) => ({
     maxWidth: "40vw"
   },
   [theme.breakpoints.up("lg")]: {
-    minWidth: "50vw"
+    "@media (min-width: 1200px) and (max-width: 2400px)": {
+      minWidth: "50vw"
+    },
+    "@media (max-width: 1200px)": {
+      minWidth: "initial"
+    }
   }
 }));

--- a/src/pages/SmartContractDetail/styles.ts
+++ b/src/pages/SmartContractDetail/styles.ts
@@ -127,7 +127,7 @@ export const StyledContractTabs = styled(Box)(() => ({
 }));
 
 export const StyledAccordionSummary = styled(AccordionSummary)(() => ({
-  padding: "25px 25px 0 25px"
+  padding: "8px 24px"
 }));
 
 export const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
@@ -146,8 +146,7 @@ export const StyledSubNameTab = styled(AccordionDetails)(({ theme }) => ({
 }));
 
 export const StyledTabName = styled(AccordionDetails)(() => ({
-  padding: "0 0 8px 0",
-  paddingLeft: "5px",
+  padding: 0,
   fontSize: 18,
   fontWeight: 700
 }));


### PR DESCRIPTION
## Description

fix UI on smart contract detail and pool detail

## Checklist before requesting a review

### Issue ticket number and link

- [x ] This PR has a valid ticket number or issue: [[link](https://jira.sotatek.com/projects/ADAE/issues/ADAE-1479?filter=myopenissues)] and  [[link](https://jira.sotatek.com/projects/ADAE/issues/ADAE-1485?filter=myopenissues)]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
1. smart contract detail
##### _Before_
![Screenshot 2023-11-16 at 13 42 29](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/1e7999e7-3246-4459-9027-0560271df23d)

##### _After_
![Screenshot 2023-11-16 at 13 41 57](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/f5fa357d-6f5a-4247-8126-856615a6076f)

2. pool detail when zoom out 50% or less
##### _Before_
![Screenshot 2023-11-16 at 13 40 51](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/6bdc459a-760e-4c29-8bcb-8ef280d3c8c6)

##### _After_
![Screenshot 2023-11-16 at 13 49 52](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/c6d12a9b-03c3-47e0-9aad-4503263257b5)



#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)