### PR TITLE
fix: MET-1801 add hover effect to lastest transactions and lastest st…

### DIFF
--- a/src/components/Home/LatestStories/style.ts
+++ b/src/components/Home/LatestStories/style.ts
@@ -1,7 +1,5 @@
-import { Box, styled } from "@mui/material";
+import { Box, styled, Card } from "@mui/material";
 import Slider from "react-slick";
-
-import { BoxRaised } from "../../commons/BoxRaised";
 
 export const LatestStoriesContainer = styled(Box)`
   text-align: center;
@@ -50,13 +48,16 @@ export const StyledSlider = styled(Slider)`
   }
 `;
 
-export const Item = styled(BoxRaised)`
+export const Item = styled(Card)`
   position: relative;
   height: 377px;
   text-align: left;
   cursor: pointer;
   overflow: hidden;
   padding: 20px 15px;
+  background: ${(props) => props.theme.palette.secondary[0]};
+  box-shadow: ${(props) => props.theme.shadow.card};
+  border-radius: 12px;
   box-sizing: border-box;
   &:hover {
     box-shadow: ${(props) => props.theme.shadow.cardHover};

--- a/src/components/Home/LatestTransactions/index.tsx
+++ b/src/components/Home/LatestTransactions/index.tsx
@@ -85,7 +85,6 @@ const LatestTransactions: React.FC = () => {
               })
             : data?.map((item) => {
                 const { hash, fromAddress, toAddress, blockNo, amount, status, time, epochNo, epochSlotNo } = item;
-
                 return (
                   // isTable show 2 item per row else show 1 item per row grid
                   <Grid item xl={3} lg={3} xs={12} sm={6} key={hash}>

--- a/src/components/Home/LatestTransactions/style.ts
+++ b/src/components/Home/LatestTransactions/style.ts
@@ -1,6 +1,5 @@
-import { Box, styled } from "@mui/material";
+import { Box, styled, Card } from "@mui/material";
 
-import { BoxRaised } from "src/components/commons/BoxRaised";
 import { TRANSACTION_STATUS } from "src/commons/utils/constants";
 
 export const TransactionContainer = styled(Box)`
@@ -68,10 +67,13 @@ export const TimeDurationSm = styled("small")(({ theme }) => ({
   }
 }));
 
-export const Item = styled(BoxRaised)`
+export const Item = styled(Card)`
   display: block;
   position: relative;
   padding: 20px;
+  background: ${(props) => props.theme.palette.secondary[0]};
+  box-shadow: ${(props) => props.theme.shadow.card};
+  border-radius: 12px;
   margin-bottom: 20px;
   border-radius: 10px;
   font-family: var(--font-family-text);


### PR DESCRIPTION
## Description

add hover effect when hover card in lastest transactions and lastest stories

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/MET-1800)]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)