### PR TITLE
fix: MET-1817 active sidebar in reset password page

### DIFF
--- a/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
+++ b/src/components/commons/Layout/Sidebar/SidebarMenu/index.tsx
@@ -34,6 +34,7 @@ const SidebarMenu: React.FC<RouteComponentProps> = ({ history }) => {
   const { isTablet } = useScreen();
 
   const isActiveMenu = (href: string, isSpecialPath?: boolean): boolean => {
+    if (href === "/" && pathname.includes("reset-password")) return true;
     if (href === pathname) return true;
     if (pathname.split("/").length > 2 && href.includes(pathname.split("/")[1])) {
       if (isSpecialPath) return href === specialPath;


### PR DESCRIPTION
## Description

 active sidebar in reset password page

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-1817)

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/2aa24d15-60db-4b15-8645-9d24426cda3a)
##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/3d40a613-635b-4537-a28f-b030964c1934)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)