### PR TITLE
Fix: [ADAE-1547]:  Stake key hyperlink dont work

### DIFF
--- a/src/components/commons/CopyButton/index.tsx
+++ b/src/components/commons/CopyButton/index.tsx
@@ -13,6 +13,7 @@ const Button = styled(IconButton)`
   width: 23px;
   height: 23px;
   font-size: var(--font-size-text-large);
+  pointer-events: auto;
 `;
 
 interface CopyButtonProps extends IconButtonProps {

--- a/src/components/commons/SPOHolder/index.tsx
+++ b/src/components/commons/SPOHolder/index.tsx
@@ -167,5 +167,6 @@ export const PoolNamePopup = styled(Link)(({ theme }) => ({
   overflow: "hidden",
   textOverflow: "ellipsis",
   flex: 1,
-  textAlign: "left"
+  textAlign: "left",
+  pointerEvents: "auto"
 }));

--- a/src/components/commons/SPOHolderBox/index.tsx
+++ b/src/components/commons/SPOHolderBox/index.tsx
@@ -36,6 +36,10 @@ const SPOHolderBox: React.FC<ISPOProps> = React.forwardRef(({ data, ...props }, 
     history.push(details.delegation(poolView));
   };
 
+  const stopPropagation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   return (
     <Container {...props} ref={boxRef}>
       <Image src={SPOHolderIconUrl} alt="SPO image" />
@@ -56,7 +60,7 @@ const SPOHolderBox: React.FC<ISPOProps> = React.forwardRef(({ data, ...props }, 
               arrow: { style: { color: theme.isDark ? "black" : "white" } }
             }}
             title={
-              <Box>
+              <Box onClick={stopPropagation}>
                 <Box display={"flex"} alignItems={"center"}>
                   <Box fontSize="1.125rem" color={({ palette }) => palette.secondary.light}>
                     {t("common.poolId")}:
@@ -78,6 +82,7 @@ const SPOHolderBox: React.FC<ISPOProps> = React.forwardRef(({ data, ...props }, 
             </ButtonSPO>
           </CustomTooltip>
           <CustomTooltip
+            leaveDelay={100}
             wOpacity={false}
             componentsProps={{
               transition: {
@@ -91,7 +96,7 @@ const SPOHolderBox: React.FC<ISPOProps> = React.forwardRef(({ data, ...props }, 
             }}
             title={
               rewardAccounts.length > 0 && (
-                <StakeKeyItemList>
+                <StakeKeyItemList onClick={stopPropagation}>
                   {rewardAccounts.map((item) => (
                     <StakeKeyItem key={item}>
                       <SPOKey fill={theme.palette.primary.main} />
@@ -103,13 +108,7 @@ const SPOHolderBox: React.FC<ISPOProps> = React.forwardRef(({ data, ...props }, 
               )
             }
           >
-            <ButtonSPO
-              ref={SPOKeyRef}
-              component={IconButton}
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
+            <ButtonSPO ref={SPOKeyRef} component={IconButton} onClick={stopPropagation}>
               <SPOKey fill={theme.palette.primary.main} />
             </ButtonSPO>
           </CustomTooltip>


### PR DESCRIPTION
## Description

- Stake key hyperlink in tooltip dont work after click SPO button
- Show table "Total operator rewards" when click in tooltip 

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)