### PR TITLE
Fix: [MET-1757]: Staking life cycle error in displaying retired and reactived pool merge test

### DIFF
--- a/src/components/ModalDescription/DeregistrationSPOProcessDescription.tsx
+++ b/src/components/ModalDescription/DeregistrationSPOProcessDescription.tsx
@@ -18,6 +18,7 @@ export function DeregistrationSPOProcessDescription({ open, handleCloseModal }: 
             <Typography>{t("desc.DeregistrationSPOProcessDescription.1st")}</Typography>
             <Typography mt={1}>{t("desc.DeregistrationSPOProcessDescription.2st")}</Typography>
             <Typography mt={1}>{t("desc.DeregistrationSPOProcessDescription.3st")}</Typography>
+            <Typography mt={1}>{t("desc.DeregistrationSPOProcessDescription.4th")}</Typography>
           </NormalDescription>
         </ContentContainer>
       </WrapContent>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -677,6 +677,7 @@
   "desc.DeregistrationSPOProcessDescription.1st": "If a stake pool wishes to cease operation, it can announce this intention by posting a stake pool retirement certificate.",
   "desc.DeregistrationSPOProcessDescription.2st": "The Stake Pool Retirement Certificate contains the public key hash of the pool and the epoch number, starting from which the stake pool will cease operation.",
   "desc.DeregistrationSPOProcessDescription.3st": "After the retirement epoch, any stake delegated to this stake pool will be disregarded and will not participate in the consensus mechanism.",
+  "desc.DeregistrationSPOProcessDescription.4th": "If a pool update posted before the deregistration epoch, it will override the deregistration.",
   "common.rewardsActivity": "Rewards Activity",
   "glossary.txType": "Transaction Type",
   "sklc.registrationCertificate": "Registration certificate",


### PR DESCRIPTION
## Description
- Update description in Deregistraion tab in Staking Life Cycle

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/240b5c44-2760-48d7-a409-6ec5d1b77c8f)

##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/984b65a1-bdd0-48d4-a5cb-b5012d6d7640)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)