### PR TITLE
fix: MET-1750 close tooltip when open popup CIP60

### DIFF
--- a/src/components/commons/CIP60Badge/index.tsx
+++ b/src/components/commons/CIP60Badge/index.tsx
@@ -4,7 +4,6 @@ import { CIP60WarningIcon, CheckedCIPIcon } from "src/commons/resources";
 
 import { BadgeContainer, CIPLabel } from "./styles";
 import CustomTooltip from "../CustomTooltip";
-import CustomIcon from "../CustomIcon";
 
 export type TCIPType = "success" | "warning";
 
@@ -20,7 +19,7 @@ const CIP60Badge: React.FC<TCIP60BadgeProps> = ({ type, tooltipTitle, onClick })
   return (
     <CustomTooltip title={tooltipTitle}>
       <BadgeContainer data-testid="clickable-cip60-badge" onClick={onClick} success={+success}>
-        {success ? <CheckedCIPIcon /> : <CustomIcon icon={CIP60WarningIcon} height={20} width={20} />}
+        {success ? <CheckedCIPIcon /> : <CIP60WarningIcon height={20} width={20} />}
         <CIPLabel>{t("token.cip60")}</CIPLabel>
       </BadgeContainer>
     </CustomTooltip>


### PR DESCRIPTION
## Description

close tooltip when open popup CIP60

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)