### PR TITLE
Fix: Sort icon in table does not track query when reload page

### DIFF
--- a/src/components/commons/Table/index.tsx
+++ b/src/components/commons/Table/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 import breakpoints from "src/themes/breakpoints";
 import { useScreen } from "src/commons/hooks/useScreen";
@@ -25,7 +26,7 @@ import {
   SortTableUpDown,
   StartPage
 } from "src/commons/resources";
-import { handleClicktWithoutAnchor, numberWithCommas } from "src/commons/utils/helper";
+import { getPageInfo, handleClicktWithoutAnchor, numberWithCommas } from "src/commons/utils/helper";
 import {
   ColumnType,
   FooterTableProps,
@@ -87,10 +88,20 @@ const TableHeader = <T extends ColumnType>({
   isModal
 }: TableHeaderProps<T>) => {
   const theme = useTheme();
+  const { search } = useLocation();
   const [{ columnKey, sort }, setSort] = useState<{ columnKey: string; sort: "" | "DESC" | "ASC" }>({
     columnKey: defaultSort ? defaultSort.split(",")[0] : "",
     sort: defaultSort ? (defaultSort.split(",")[1] as "" | "DESC" | "ASC") : ""
   });
+
+  useEffect(() => {
+    const { sort: sortQueryString } = getPageInfo(search);
+    if (sortQueryString && sortQueryString.length) {
+      const [columnKey, sort] = sortQueryString.split(",") as [string, "" | "DESC" | "ASC"];
+      setSort({ columnKey, sort });
+    }
+  }, [search]);
+
   const sortValue = ({ key, sort }: { key: string; sort: "" | "DESC" | "ASC" }) => {
     if (key === columnKey) {
       switch (sort) {


### PR DESCRIPTION
## Description

When click icon sort and reload page, only data in table sort however the sort icon does not update

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/e97d05ad-f749-49f4-a518-da6615cb022e)
> (Add screenshots)

##### _After_

[comment]: <
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/50411344-31fe-4427-a1b0-42753d6cbbc7)
> (Add screenshots)


