### PR TITLE
fix: border radius to match rest of the inputs

### DIFF
--- a/src/components/commons/Layout/Sidebar/index.tsx
+++ b/src/components/commons/Layout/Sidebar/index.tsx
@@ -62,7 +62,8 @@ const Sidebar: React.FC = () => {
               }}
               color={muiTheme.isDark ? muiTheme.palette.secondary.light : muiTheme.palette.primary.main}
               bgcolor={muiTheme.isDark ? "transparent" : muiTheme.palette.primary[200]}
-              border={`1px solid ${muiTheme.isDark ? muiTheme.palette.primary[100] : muiTheme.palette.primary.main} `}
+              border={`2px solid ${muiTheme.isDark ? muiTheme.palette.primary[100] : muiTheme.palette.primary.main} `}
+              borderRadius={"8px"}
               fontSize={16}
             >
               <Box
@@ -81,8 +82,9 @@ const Sidebar: React.FC = () => {
               fontSize={16}
               color={muiTheme.isDark ? muiTheme.palette.primary.main : muiTheme.palette.secondary.light}
               bgcolor={muiTheme.isDark ? muiTheme.palette.secondary[0] : "transparent"}
-              border={`1px solid ${muiTheme.isDark ? muiTheme.palette.primary.main : muiTheme.palette.primary[200]} `}
-              borderLeft={`1px solid ${
+              border={`2px solid ${muiTheme.isDark ? muiTheme.palette.primary.main : muiTheme.palette.primary[200]} `}
+              borderRadius={"8px"}
+              borderLeft={`2px solid ${
                 muiTheme.isDark ? muiTheme.palette.primary.main : muiTheme.palette.primary.main
               } !important`}
             >


### PR DESCRIPTION
## Description

before

![Screenshot 2023-12-15 at 09 28 54](https://github.com/cardano-foundation/cf-explorer-frontend/assets/110593455/1bb9f92e-9c86-4366-bc23-307de9e513ea)

after

<img width="314" alt="Screenshot 2023-12-15 at 10 54 41" src="https://github.com/cardano-foundation/cf-explorer-frontend/assets/110593455/69dd7d05-f7ab-4c09-86d3-2e67eb1fe69e">
