### PR TITLE
Fix: Bug sort icon does not track query

### DIFF
--- a/src/components/ReceivedRewardsModal/index.tsx
+++ b/src/components/ReceivedRewardsModal/index.tsx
@@ -96,10 +96,10 @@ const ReceivedRewardsModal: React.FC<ReceivedRewardsModalProps> = ({ open = fals
       }
     },
     {
-      key: "time",
+      key: "id",
       title: t("common.Date"),
-      sort: ({ sortValue }) => {
-        sortValue ? setSort(`id,${sortValue}`) : setSort("");
+      sort: ({ sortValue, columnKey }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
       },
       render(data) {
         return <Box>{formatDateTimeLocal(data.time)}</Box>;

--- a/src/components/ReportGeneratedStakingDetail/StakeyTabs/RewardsDistributionTab.tsx
+++ b/src/components/ReportGeneratedStakingDetail/StakeyTabs/RewardsDistributionTab.tsx
@@ -53,11 +53,11 @@ const RewardsDistributionTab = () => {
     },
     {
       title: t("createdAt"),
-      key: "time",
+      key: "id",
       minWidth: "120px",
       render: (r) => formatDateTimeLocal(r.time),
-      sort: ({ sortValue }) => {
-        sortValue ? setSort(`id,${sortValue}`) : setSort("");
+      sort: ({ sortValue, columnKey }) => {
+        sortValue ? setSort(`${columnKey},${sortValue}`) : setSort("");
       }
     },
     {


### PR DESCRIPTION
## Description

- In saved report of staking lifecycle page, sort icon does not track query

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)