### PR TITLE
Fix: Bug sort icon in table merge test

### DIFF
--- a/src/components/commons/Table/index.tsx
+++ b/src/components/commons/Table/index.tsx
@@ -98,7 +98,7 @@ const TableHeader = <T extends ColumnType>({
     const { sort: sortQueryString } = getPageInfo(search);
     if (sortQueryString && sortQueryString.length) {
       const [columnKey, sort] = sortQueryString.split(",") as [string, "" | "DESC" | "ASC"];
-      setSort({ columnKey, sort });
+      setSort({ columnKey: columnKey.startsWith("bk.") ? columnKey.slice(3) : columnKey, sort });
     } else {
       setSort({ columnKey: "", sort: "" });
     }


### PR DESCRIPTION
## Description

- Sort icon does not track query when sort by key bk.time (because column key is "time" is diffrent from "bk.time", therefore does not update sort icon)

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/4e069a08-ca2f-4442-abf6-4b9df751812d)

##### _After_

[comment]: <> (Add screenshots)
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/69024094-685f-4b3c-9b28-3a97d6b2fe8d)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)