### PR TITLE
fix: copy icon on deregistration certificate modal

### DIFF
--- a/src/components/commons/DeregistrationCertificateModal/index.tsx
+++ b/src/components/commons/DeregistrationCertificateModal/index.tsx
@@ -22,20 +22,33 @@ export const DeregistrationCertificateModal = ({
   const { data, loading } = useFetch<IStakeKeyDetail>(`${API.STAKE.DETAIL}/${stake}`, undefined, false);
 
   return (
-    <StyledModal {...props} width={550} title={t("common.deregistrationCert")}>
-      <Box>
+    <StyledModal {...props} width={"fit-content"} title={t("common.deregistrationCert")}>
+      <Box
+        sx={{
+          wordBreak: "break-word",
+          maxWidth: "min(90vw, 1200px)"
+        }}
+      >
         {loading && <CommonSkeleton variant="rectangular" width={500} height={90} />}
         {!loading && (
           <StyledContainerModal>
-            <Box fontWeight={"bold"} fontSize={"0.875rem"} color={({ palette }) => palette.secondary.light}>
+            <Box
+              marginBottom={1}
+              fontWeight={"bold"}
+              fontSize={"0.875rem"}
+              color={({ palette }) => palette.secondary.light}
+            >
               {t("common.stakeAddress")}
             </Box>
             {data && (
-              <Box>
-                <Box>
-                  <StakeLink to={details.stake(stake)}>{stake || ""}</StakeLink>
-                  <CopyButton text={stake} />
-                </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center"
+                }}
+              >
+                <StakeLink to={details.stake(stake)}>{stake || ""}</StakeLink>
+                <CopyButton text={stake} />
               </Box>
             )}
           </StyledContainerModal>

--- a/src/components/commons/DeregistrationCertificateModal/styles.ts
+++ b/src/components/commons/DeregistrationCertificateModal/styles.ts
@@ -13,7 +13,4 @@ export const StakeLink = styled(Link)`
   font-size: 0.875rem;
   color: ${({ theme }) => theme.palette.primary.main} !important;
   margin-right: 6px;
-  ${({ theme }) => theme.breakpoints.down(theme.breakpoints.values.sm)} {
-    overflow-wrap: break-word;
-  }
 `;


### PR DESCRIPTION
## Description

 fix copy icon on deregistration certificate modal

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![Screenshot 2023-12-27 at 18 10 23](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/3afb0353-bd7f-41dd-b1df-227fb2573254)


![Screenshot 2023-12-27 at 18 10 56](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/a7107534-bcef-4f96-abc2-4feac52ec4fd)
##### _After_
![Screenshot 2023-12-27 at 18 07 22](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/2b1019b3-e474-4627-893d-cdfacd07ea39)

![Screenshot 2023-12-27 at 17 08 15](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/0a5af849-0e8e-4442-a9e0-fa2b08c7d65b)
42db-aba2-a8a6f13ec2d3)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)