### PR TITLE
fix: Disable Sign button when show Popup connect wallet

### DIFF
--- a/src/components/StakeDetail/ModalAllAddress/index.tsx
+++ b/src/components/StakeDetail/ModalAllAddress/index.tsx
@@ -63,6 +63,7 @@ const ModalAllAddress: React.FC<ModalAllAddressProps> = ({ stake, ...props }) =>
       width={"600px"}
       height={"auto"}
       contentStyle={{ overflowY: "unset" }}
+      isCenterWithoutPosition={true}
     >
       <WrapContent>
         <Table

--- a/src/components/TokenAutocomplete/index.tsx
+++ b/src/components/TokenAutocomplete/index.tsx
@@ -231,7 +231,13 @@ const ModalToken = ({ open, onClose, address }: { open: boolean; onClose: () => 
   };
 
   return (
-    <CustomModal title={t("glossary.tokenList")} open={open} onClose={handleClose} width={"min(80vw, 600px)"}>
+    <CustomModal
+      title={t("glossary.tokenList")}
+      open={open}
+      onClose={handleClose}
+      width={"min(80vw, 600px)"}
+      isCenterWithoutPosition={true}
+    >
       <>
         <SearchContainer mt={2} mb={1}>
           <StyledInput

--- a/src/components/commons/ConnectWalletModal/index.tsx
+++ b/src/components/commons/ConnectWalletModal/index.tsx
@@ -72,6 +72,12 @@ const ConnectWalletModal: React.FC<IProps> = ({
   }, [walletMenu]);
 
   useEffect(() => {
+    if (p2pOptionModal == null && isP2Pconnect) {
+      setOpenModal(false);
+    }
+  }, [p2pOptionModal]);
+
+  useEffect(() => {
     function copyToClipboard(text: string) {
       navigator.clipboard
         .writeText(text)

--- a/src/components/commons/Layout/Header/ConnectWallet/index.tsx
+++ b/src/components/commons/Layout/Header/ConnectWallet/index.tsx
@@ -40,10 +40,11 @@ const ConnectWallet: React.FC<Props> = ({ customButton, onSuccess }) => {
     limitNetwork: NETWORK === NETWORKS.mainnet ? NetworkType.MAINNET : NetworkType.TESTNET
   });
   const isValidToken = validateTokenExpired();
-  const [signature, setSignature] = React.useState("");
+  const [signature, setSignature] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [isSign, setIsSign] = useState(isValidToken);
-  const [isSignP2P, setIsSignP2P] = React.useState(false);
+  const [isSignP2P, setIsSignP2P] = useState(false);
+  const [disableSignButton, setDisableSignButton] = useState(false);
 
   const handleSignP2P = () => {
     setIsSignP2P(!isSignP2P);
@@ -105,6 +106,7 @@ const ConnectWallet: React.FC<Props> = ({ customButton, onSuccess }) => {
         setUserData({ ...userInfo.data, loginType: "connectWallet" });
       } else {
         setAddress(stakeAddress);
+        !isSignP2P && setDisableSignButton(true);
         setModalRegister(true);
       }
       onSuccess?.();
@@ -122,12 +124,14 @@ const ConnectWallet: React.FC<Props> = ({ customButton, onSuccess }) => {
       const nonceValue = await getNonceValue();
       if (nonceValue) {
         setNonce(nonceValue);
+        !isSignP2P && setDisableSignButton(true);
         await signMessage(
           nonceValue.nonce,
           (signature: string) => handleSignIn(signature, nonceValue),
           () => {
             toast.error(t("message.user.rejected"));
             setModalSignMessage(false);
+            setDisableSignButton(false);
             disconnect();
             removeAuthInfo();
           }
@@ -197,12 +201,14 @@ const ConnectWallet: React.FC<Props> = ({ customButton, onSuccess }) => {
         open={modalSignMessage}
         handleCloseModal={() => {
           setModalSignMessage(false);
+          setDisableSignButton(false);
           disconnect();
           removeAuthInfo();
         }}
         onSignMessage={onSignMessage}
         loadingSubmit={submitting}
         isSignP2P={isSignP2P}
+        disableSignButton={disableSignButton}
       />
       <RegisterUsernameModal open={modalRegister} nonce={nonce} signature={signature} setIsSign={setIsSign} />
     </Box>

--- a/src/components/commons/Layout/Header/SignMessageModal/SignMessageModal.test.tsx
+++ b/src/components/commons/Layout/Header/SignMessageModal/SignMessageModal.test.tsx
@@ -6,7 +6,8 @@ const mockProps = {
   open: true,
   loadingSubmit: false,
   handleCloseModal: jest.fn(),
-  onSignMessage: jest.fn()
+  onSignMessage: jest.fn(),
+  disableSignButton: false
 };
 
 describe("SignMessageModal component", () => {

--- a/src/components/commons/Layout/Header/SignMessageModal/index.tsx
+++ b/src/components/commons/Layout/Header/SignMessageModal/index.tsx
@@ -14,8 +14,16 @@ type TProps = {
   handleCloseModal: () => void;
   onSignMessage: () => void;
   isSignP2P?: boolean;
+  disableSignButton: boolean;
 };
-const SignMessageModal: React.FC<TProps> = ({ open, isSignP2P, loadingSubmit, handleCloseModal, onSignMessage }) => {
+const SignMessageModal: React.FC<TProps> = ({
+  open,
+  isSignP2P,
+  loadingSubmit,
+  handleCloseModal,
+  onSignMessage,
+  disableSignButton
+}) => {
   const { t } = useTranslation();
   const [p2pAlert, setP2pAlert] = useState(false);
 
@@ -39,6 +47,7 @@ const SignMessageModal: React.FC<TProps> = ({ open, isSignP2P, loadingSubmit, ha
             }}
             loading={loadingSubmit}
             loadingPosition="end"
+            disabled={disableSignButton}
           >
             {t("account.sign")}
           </StyledDarkLoadingButton>


### PR DESCRIPTION
## Description

Disable Sign button when show Popup connect wallet

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![Screenshot 2023-12-29 at 10 31 27](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/be568724-2972-4126-b2ba-cd719ee37f3f)

##### _After_

![Screenshot 2023-12-29 at 10 31 01](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/dae99a6e-e19d-4b02-81e6-e2b59be2e1b4)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)