### PR TITLE
fix: transaction meta data ui bug

### DIFF
--- a/src/components/TransactionDetail/TransactionMetadata/UTXOs/index.tsx
+++ b/src/components/TransactionDetail/TransactionMetadata/UTXOs/index.tsx
@@ -68,7 +68,7 @@ const Card = ({
       return prv + +item.value;
     }, 0);
 
-  const { isMobile } = useScreen();
+  const { isMobile, width } = useScreen();
   const theme = useTheme();
   const ADAIconAmount = () => (
     <ADAicon sx={{ color: isFailed ? theme.palette.secondary[600] : theme.palette.secondary.main }} />
@@ -112,9 +112,21 @@ const Card = ({
       <Box fontSize={14}>
         {items?.map((item, index) => (
           <Item key={index}>
-            <ItemContent>
+            <ItemContent
+              sx={{
+                overflow: "unset!important"
+              }}
+            >
               <WrapIcon type={type}>{renderIcon(type)}</WrapIcon>
-              <WrapInfo>
+              <WrapInfo
+                sx={
+                  width < 400
+                    ? {
+                        width: "calc(100% - 38px)"
+                      }
+                    : {}
+                }
+              >
                 <WrapLeftSide>
                   {type === "down" ? (
                     <WrapUTXOs>


### PR DESCRIPTION
## Description

 fix transaction meta data ui bug

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![Screenshot 2024-01-03 at 16 19 51](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/4c892ad9-90e3-4fd7-bf24-45e415b87c8c)

![Screenshot 2024-01-03 at 16 20 06](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/658c7480-cad8-4563-8f1c-209ef3602b0d)
0a35-a52d-47cd-b1ff-c134c785e2ce)


##### _After_
![Screenshot 2024-01-03 at 16 19 03](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/d18a8e79-e7bb-4583-913a-89ea2de2712f)
![Screenshot 2024-01-03 at 16 19 28](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/87ee08a7-a33e-4548-b0d9-ef8c9f99db2d)


#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)