### PR TITLE
Fix: Bug UI pool detail

### DIFF
--- a/src/components/DelegationDetail/DelegationDetailInfo/index.tsx
+++ b/src/components/DelegationDetail/DelegationDetailInfo/index.tsx
@@ -314,7 +314,11 @@ const DelegationDetailInfo: React.FC<IDelegationDetailInfo> = ({ data, loading, 
             <InfoValue sx={{ wordBreak: "break-word" }}>
               <FlexGap10>
                 {data?.poolSize != null ? formatADAFull(data?.poolSize) : t("common.notAvailable")}
-                {data?.poolSize != null ? <ADAicon /> : ""}
+                {data?.poolSize != null ? (
+                  <Box width={16}>
+                    <ADAicon />
+                  </Box>
+                ) : null}
               </FlexGap10>
             </InfoValue>
           </Item>
@@ -327,7 +331,9 @@ const DelegationDetailInfo: React.FC<IDelegationDetailInfo> = ({ data, loading, 
               {data?.stakeLimit != null ? (
                 <FlexGap10>
                   {formatADAFull(data?.stakeLimit)}
-                  <ADAicon />
+                  <Box width={16}>
+                    <ADAicon />
+                  </Box>
                 </FlexGap10>
               ) : (
                 <FlexGap10>{t("common.notAvailable")}</FlexGap10>

--- a/src/components/DynamicEllipsisText/index.tsx
+++ b/src/components/DynamicEllipsisText/index.tsx
@@ -7,17 +7,14 @@ import { useScreen } from "src/commons/hooks/useScreen";
 
 import CustomTooltip from "../commons/CustomTooltip";
 
-const Container = styled(Box)(({ theme, whiteSpace }) => ({
-  display: "inline-block",
-  whiteSpace: "nowrap",
-  overflow: "hidden",
-  width: "100%",
-  textAlign: "left",
-  transform: "translateY(2px)",
-  [theme.breakpoints.down("sm")]: {
-    whiteSpace: whiteSpace
-  }
-}));
+const Container = styled(Box)<{ whiteSpace?: "nowrap" | "normal" }>`
+  display: inline-block;
+  white-space: ${({ whiteSpace }) => whiteSpace ?? "nowrap"};
+  overflow: hidden;
+  width: 100%;
+  text-align: left;
+  transform: translateY(2px);
+`;
 
 const SubPart = styled("span")`
   display: inline-block;


### PR DESCRIPTION
## Description

- ADAicon is not uniformly
- Stakelink is hidden in around 1120px screen width

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/0a517c47-4ea9-4d8f-a763-c7ce34e3d5ff)

[comment]: <> (Add screenshots)

##### _After_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/120eedad-163c-4109-ba10-7c4682b59868)

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)