### PR TITLE
Fix : met 1972 epoch status display is incorrect while syncing

### DIFF
--- a/src/components/commons/Epoch/FirstEpoch/index.tsx
+++ b/src/components/commons/Epoch/FirstEpoch/index.tsx
@@ -53,12 +53,12 @@ export default function FirstEpoch({ data: currentEpochData, onClick }: IProps) 
             percent={Number(progress)}
             trailOpacity={1}
           >
-            {currentEpochData?.status === EPOCH_STATUS.SYNCING.toUpperCase() ? (
-              currentEpochData?.no
-            ) : (
+            {currentEpochData?.status !== EPOCH_STATUS.SYNCING.toUpperCase() ? (
               <EpochProgress
                 status={currentEpochData?.status as keyof typeof EPOCH_STATUS}
               >{`${progress}%`}</EpochProgress>
+            ) : (
+              currentEpochData?.no
             )}
 
             <Status status={currentEpochData?.status as keyof typeof EPOCH_STATUS}>


### PR DESCRIPTION
## Description

Fix/met 1972 epoch status display is incorrect while syncing

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [https://cardanofoundation.atlassian.net/browse/MET-1972]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)