### PR TITLE
fix: fixed publish job configuration to prevent from running when dependabot trigger build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,8 +21,9 @@ jobs:
       packages: write
     runs-on: self-hosted
     if: |
-      "contains(github.event.head_commit.message, 'release-please--branches--main')" ||
-      ${{ github.event_name == 'pull_request' }}
+      ${{ github.actor != 'dependabot[bot]' }} &&
+      ( "contains(github.event.head_commit.message, 'release-please--branches--main')" ||
+      ${{ github.event_name == 'pull_request' }} )
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixed gha for publish job to be skipped if triggered by dependabot