### PR TITLE
fix: MET-2051 add missing text tooltip pool name

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -69,7 +69,18 @@ const DelegationLists: React.FC = () => {
       minWidth: "200px",
       maxWidth: "200px",
       render: (r) => (
-        <CustomTooltip title={r.tickerName || ""}>
+        <CustomTooltip
+          title={
+            r.tickerName ? (
+              <>
+                <Box fontWeight={"bold"} component={"span"}>
+                  Ticker:{" "}
+                </Box>
+                {r.tickerName}
+              </>
+            ) : undefined
+          }
+        >
           <PoolName to={{ pathname: details.delegation(r.poolId), state: { fromPath } }}>
             <Box component={"span"} textOverflow={"ellipsis"} whiteSpace={"nowrap"} overflow={"hidden"}>
               {r.poolName || `${getShortHash(r.poolId)}`}


### PR DESCRIPTION
## Description

add missing text tooltip pool name

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link]](https://cardanofoundation.atlassian.net/browse/MET-2051)

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/67336c73-56df-45d4-bdac-bfa9a36f4c64)

##### _After_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/117699295/a881f53e-48cf-43ac-ae98-5265d33d14d2)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)