### PR TITLE
Fix/met 2107 pools filter option text field not being reset after search results

### DIFF
--- a/src/components/commons/CustomFilterMultiRange/index.tsx
+++ b/src/components/commons/CustomFilterMultiRange/index.tsx
@@ -89,7 +89,7 @@ const CustomFilterMultiRange: React.FC = () => {
       page: query?.page && +query?.page >= 1 ? +query?.page - 1 : 0,
       size: +(query?.voteSize || "") || 50,
       sort: (query?.sort || "").toString(),
-      ...(query?.query && { query: query?.query.toString() || "" }),
+      query: "",
       ...(query?.maxPoolSize && { maxPoolSize: +(query?.maxPoolSize || 0) }),
       ...(query?.minPoolSize && { minPoolSize: +(query?.minPoolSize || 0) }),
       ...(query?.minPledge && { minPledge: +(query?.minPledge || 0) }),


### PR DESCRIPTION
## Description

 reset poolName after search results

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)