### PR TITLE
fix: MET 2110 Pools Overview Pools table show Retired pools should mo…

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -17,7 +17,7 @@ import CustomTooltip from "src/components/commons/CustomTooltip";
 import Table, { Column } from "src/components/commons/Table";
 import { CONWAY_ERE_FEILD, FF_GLOBAL_IS_CONWAY_ERA } from "src/commons/utils/constants";
 
-import { AntSwitch, PoolName, ShowRetiredPools, TopSearchContainer } from "./styles";
+import { PoolName, TopSearchContainer } from "./styles";
 
 const DelegationLists: React.FC = () => {
   const { t } = useTranslation();
@@ -25,7 +25,6 @@ const DelegationLists: React.FC = () => {
   const { tickerNameSearch = "" } = history.location.state || {};
   const [search, setSearch] = useState(decodeURIComponent(tickerNameSearch));
   const { pageInfo, setSort } = usePageInfo();
-  const [isShowRetired, setIsRetired] = useState(/^true$/i.test(pageInfo.retired));
 
   const tableRef = useRef<HTMLDivElement>(null);
   const blockKey = useSelector(({ system }: RootState) => system.blockKey);
@@ -46,8 +45,8 @@ const DelegationLists: React.FC = () => {
   const fetchData = useFetchList<Delegators>(
     API.DELEGATION.POOL_LIST,
     {
-      isShowRetired: isShowRetired,
-      ...newPageInfo
+      ...newPageInfo,
+      isShowRetired: newPageInfo.retired
     },
     false,
     blockKey
@@ -229,17 +228,6 @@ const DelegationLists: React.FC = () => {
     <>
       <TopSearchContainer sx={{ justifyContent: "end" }}>
         <Box display="flex" gap="10px">
-          <ShowRetiredPools>
-            <Box data-testid="delegationList.retiredPoolsTitle">{t("glassary.showRetiredPools")}</Box>
-            <AntSwitch
-              data-testid="poolList.retiredValue"
-              checked={isShowRetired}
-              onChange={(e) => {
-                setIsRetired(e.target.checked);
-                history.replace({ search: stringify({ ...pageInfo, page: 0, retired: e.target.checked }) });
-              }}
-            />
-          </ShowRetiredPools>
           <CustomFilterMultiRange />
         </Box>
       </TopSearchContainer>

--- a/src/components/commons/CustomFilterMultiRange/index.tsx
+++ b/src/components/commons/CustomFilterMultiRange/index.tsx
@@ -22,6 +22,7 @@ import { LARGE_NUMBER_ABBREVIATIONS, formatADA, formatPercent } from "src/common
 import { FilterWrapper } from "src/pages/NativeScriptsAndSC/styles";
 import usePageInfo from "src/commons/hooks/usePageInfo";
 import { FF_GLOBAL_IS_CONWAY_ERA } from "src/commons/utils/constants";
+import { AntSwitch } from "src/components/DelegationPool/DelegationList/styles";
 
 import { ApplyFilterButton, StyledInput } from "../CustomFilter/styles";
 import { AccordionContainer, AccordionDetailsFilter, FilterContainer, StyledSlider } from "./styles";
@@ -62,6 +63,7 @@ const CustomFilterMultiRange: React.FC = () => {
   const handleChange = (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
     setExpanded(newExpanded ? panel : false);
   };
+  const [isShowRetired, setIsRetired] = useState(/^true$/i.test(pageInfo.retired));
   const fetchDataRange = useFetch<PoolResponse>(API.POOL_RANGE_VALUES);
   const dataRange = fetchDataRange.data;
   const initParams = {
@@ -187,6 +189,32 @@ const CustomFilterMultiRange: React.FC = () => {
         </Box>
         {open && (
           <FilterContainer>
+            <AccordionContainer data-testid="filterRange.retiredPools">
+              <AccordionSummary>
+                <Box width={"100%"} display={"flex"} alignItems={"center"} justifyContent={"space-between"}>
+                  <Box display={"flex"} alignItems={"center"}>
+                    <Box color={({ palette }) => palette.secondary.main} data-testid="delegationList.retiredPoolsTitle">
+                      {t("glassary.showRetiredPools")}
+                    </Box>
+                  </Box>
+
+                  <AntSwitch
+                    data-testid="poolList.retiredValue"
+                    checked={isShowRetired}
+                    onChange={(e) => {
+                      setIsRetired(e.target.checked);
+                      history.replace({
+                        search: stringify({
+                          ...pageInfo,
+                          page: 0,
+                          retired: e.target.checked
+                        })
+                      });
+                    }}
+                  />
+                </Box>
+              </AccordionSummary>
+            </AccordionContainer>
             <Box display={"flex"} flexDirection={"column"}>
               <AccordionContainer
                 data-testid="filterRange.poolName"


### PR DESCRIPTION
…ve to Filters

## Description

move retired to filter

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)