### PR TITLE
fix: MET 2110 Pools Overview Pools table show Retired pools should move to filters

### DIFF
--- a/src/components/DelegationPool/DelegationList/index.tsx
+++ b/src/components/DelegationPool/DelegationList/index.tsx
@@ -17,7 +17,7 @@ import CustomTooltip from "src/components/commons/CustomTooltip";
 import Table, { Column } from "src/components/commons/Table";
 import { CONWAY_ERE_FEILD, FF_GLOBAL_IS_CONWAY_ERA } from "src/commons/utils/constants";
 
-import { AntSwitch, PoolName, ShowRetiredPools, TopSearchContainer } from "./styles";
+import { DelegationContainer, PoolName, TopSearchContainer } from "./styles";
 
 const DelegationLists: React.FC = () => {
   const { t } = useTranslation();
@@ -25,7 +25,6 @@ const DelegationLists: React.FC = () => {
   const { tickerNameSearch = "" } = history.location.state || {};
   const [search, setSearch] = useState(decodeURIComponent(tickerNameSearch));
   const { pageInfo, setSort } = usePageInfo();
-  const [isShowRetired, setIsRetired] = useState(/^true$/i.test(pageInfo.retired));
 
   const tableRef = useRef<HTMLDivElement>(null);
   const blockKey = useSelector(({ system }: RootState) => system.blockKey);
@@ -46,8 +45,8 @@ const DelegationLists: React.FC = () => {
   const fetchData = useFetchList<Delegators>(
     API.DELEGATION.POOL_LIST,
     {
-      isShowRetired: isShowRetired,
-      ...newPageInfo
+      ...newPageInfo,
+      isShowRetired: newPageInfo.retired
     },
     false,
     blockKey
@@ -226,20 +225,9 @@ const DelegationLists: React.FC = () => {
     }
   ];
   return (
-    <>
+    <DelegationContainer>
       <TopSearchContainer sx={{ justifyContent: "end" }}>
         <Box display="flex" gap="10px">
-          <ShowRetiredPools>
-            <Box data-testid="delegationList.retiredPoolsTitle">{t("glassary.showRetiredPools")}</Box>
-            <AntSwitch
-              data-testid="poolList.retiredValue"
-              checked={isShowRetired}
-              onChange={(e) => {
-                setIsRetired(e.target.checked);
-                history.replace({ search: stringify({ ...pageInfo, page: 0, retired: e.target.checked }) });
-              }}
-            />
-          </ShowRetiredPools>
           <CustomFilterMultiRange />
         </Box>
       </TopSearchContainer>
@@ -263,7 +251,7 @@ const DelegationLists: React.FC = () => {
           }
         }}
       />
-    </>
+    </DelegationContainer>
   );
 };
 

--- a/src/components/DelegationPool/DelegationList/styles.ts
+++ b/src/components/DelegationPool/DelegationList/styles.ts
@@ -40,6 +40,11 @@ export const SearchContainer = styled("div")(({ theme }) => ({
   }
 }));
 
+export const DelegationContainer = styled("div")(() => ({
+  "& .table-wrapper tbody": {
+    zIndex: 10
+  }
+}));
 export const StyledInput = styled("input")`
   border: none;
   width: 100%;

--- a/src/components/commons/CustomFilterMultiRange/index.tsx
+++ b/src/components/commons/CustomFilterMultiRange/index.tsx
@@ -22,6 +22,7 @@ import { LARGE_NUMBER_ABBREVIATIONS, formatADA, formatPercent } from "src/common
 import { FilterWrapper } from "src/pages/NativeScriptsAndSC/styles";
 import usePageInfo from "src/commons/hooks/usePageInfo";
 import { FF_GLOBAL_IS_CONWAY_ERA } from "src/commons/utils/constants";
+import { AntSwitch } from "src/components/DelegationPool/DelegationList/styles";
 
 import { ApplyFilterButton, StyledInput } from "../CustomFilter/styles";
 import { AccordionContainer, AccordionDetailsFilter, FilterContainer, StyledSlider } from "./styles";
@@ -32,6 +33,8 @@ interface PoolResponse {
   query?: string;
   size?: number;
   sort?: string;
+  isShowRetired?: boolean;
+  retired?: boolean;
   minPoolSize?: number;
   maxPoolSize?: number;
   minPledge?: number;
@@ -62,6 +65,7 @@ const CustomFilterMultiRange: React.FC = () => {
   const handleChange = (panel: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
     setExpanded(newExpanded ? panel : false);
   };
+  const [isShowRetired, setIsRetired] = useState<boolean>(/^true$/i.test(pageInfo.retired));
   const fetchDataRange = useFetch<PoolResponse>(API.POOL_RANGE_VALUES);
   const dataRange = fetchDataRange.data;
   const initParams = {
@@ -85,6 +89,7 @@ const CustomFilterMultiRange: React.FC = () => {
   const [filterParams, setFilterParams] = useState<PoolResponse>({});
 
   useEffect(() => {
+    setIsRetired(query.retired === "true" || false);
     setFilterParams({
       page: query?.page && +query?.page >= 1 ? +query?.page - 1 : 0,
       size: +(query?.voteSize || "") || 50,
@@ -116,7 +121,14 @@ const CustomFilterMultiRange: React.FC = () => {
     setOpen(false);
     setFilterParams({ ...filterParams });
     history.replace({
-      search: stringify({ ...filterParams, size: pageInfo.size, sort: pageInfo.sort, page: 1 }),
+      search: stringify({
+        ...filterParams,
+        size: pageInfo.size,
+        sort: pageInfo.sort,
+        page: 1,
+        isShowRetired: isShowRetired,
+        retired: isShowRetired
+      }),
       state: undefined
     });
   };
@@ -187,6 +199,25 @@ const CustomFilterMultiRange: React.FC = () => {
         </Box>
         {open && (
           <FilterContainer>
+            <AccordionContainer data-testid="filterRange.retiredPools">
+              <AccordionSummary>
+                <Box width={"100%"} display={"flex"} alignItems={"center"} justifyContent={"space-between"}>
+                  <Box display={"flex"} alignItems={"center"}>
+                    <Box color={({ palette }) => palette.secondary.main} data-testid="delegationList.retiredPoolsTitle">
+                      {t("glassary.showRetiredPools")}
+                    </Box>
+                  </Box>
+
+                  <AntSwitch
+                    data-testid="poolList.retiredValue"
+                    checked={isShowRetired}
+                    onChange={(e) => {
+                      setIsRetired(e.target.checked);
+                    }}
+                  />
+                </Box>
+              </AccordionSummary>
+            </AccordionContainer>
             <Box display={"flex"} flexDirection={"column"}>
               <AccordionContainer
                 data-testid="filterRange.poolName"

--- a/src/components/commons/CustomFilterMultiRange/styles.ts
+++ b/src/components/commons/CustomFilterMultiRange/styles.ts
@@ -78,12 +78,12 @@ export const FilterContainer = styled(Box)(({ theme }) => ({
   zIndex: 15,
   position: "absolute",
   top: "calc(100% + 10px)",
-  right: 10,
+  right: 0,
   borderRadius: theme.spacing(1),
   boxShadow: "rgba(189, 197, 209, 0.2) 0px 0.5rem 1.2rem",
   [theme.breakpoints.down("sm")]: {
     width: 250,
-    right: -17,
+    right: 0,
     "& p": {
       fontSize: "13px"
     },

--- a/src/components/commons/Filter/styles.ts
+++ b/src/components/commons/Filter/styles.ts
@@ -36,11 +36,14 @@ export const FilterContent = styled(Box)<{ isMobile?: boolean }>`
     z-index: 9;
     position: absolute;
     top: -6px;
-    right: ${({ isMobile }) => (isMobile ? "40%" : "32px")};
+    right: ${({ isMobile }) => (isMobile ? "10%" : "32px")};
     width: 14px;
     height: 16px;
     transform: rotate(45deg);
     box-shadow: 0 0.5rem 1.2rem rgb(189 197 209 / 20%);
+  }
+  ${({ theme }) => theme.breakpoints.down("sm")} {
+    right: 152%;
   }
 `;
 


### PR DESCRIPTION
…ve to filter

## Description

move show Retired  to filters

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [https://cardanofoundation.atlassian.net/browse/MET-2110]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)