### PR TITLE
fix: MET-2200 UAT Preprod Pool Details Cards are not loading

### DIFF
--- a/src/components/commons/Layout/Header/HeaderSearch/index.tsx
+++ b/src/components/commons/Layout/Header/HeaderSearch/index.tsx
@@ -354,7 +354,7 @@ const HeaderSearch: React.FC<Props> = ({ home, callback, setShowErrorMobile, his
       const url =
         filter === "tokens"
           ? `${API.TOKEN.LIST}?page=0&size=${RESULT_SIZE}&${stringify({ query: query })}`
-          : `${API.DELEGATION.POOL_LIST}?${stringify({ query: query })}&page=0&size=${RESULT_SIZE}`;
+          : `${API.DELEGATION.POOL_LIST}?${stringify({ query: query })}&page=0&size=${RESULT_SIZE}&isShowRetired=true`;
 
       const res = await defaultAxios.get(url);
       setTotalResult(res?.data && res.data?.totalItems ? res.data?.totalItems : 0);

--- a/src/pages/DelegationDetail/index.tsx
+++ b/src/pages/DelegationDetail/index.tsx
@@ -85,7 +85,7 @@ const DelegationDetail: React.FC = () => {
 
   const fetchListPools = useFetchList<Delegators>(
     API.DELEGATION.POOL_LIST,
-    { query: poolId },
+    { query: poolId, isShowRetired: true },
     false,
     tab === "epochs" ? blockKey : undefined
   );


### PR DESCRIPTION
## Description

Please include a summary of the changes and a brief description about this PR

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [MET-2200]
- https://cardanofoundation.atlassian.net/jira/software/c/projects/MET/boards/33/backlog?selectedIssue=MET-2200

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/3519beab-fd17-4c21-8628-34cd1afda750)


[comment]: <> (Add screenshots)

##### _After_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/11d5567f-5606-419a-854e-e21807800e04)


[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

[MET-2200]: https://cardanofoundation.atlassian.net/browse/MET-2200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ