### PR TITLE
fix: MET-2023 Identity new SC

### DIFF
--- a/src/components/Contracts/common/styles.ts
+++ b/src/components/Contracts/common/styles.ts
@@ -27,6 +27,7 @@ export const DataCardBox = styled(Box)`
   background-color: ${({ theme }) => (theme.isDark ? theme.palette.secondary[100] : theme.palette.common.white)};
   gap: 5px;
   min-height: 80px;
+  height: 100%;
 `;
 
 export const DataTitle = styled(Typography)`

--- a/src/components/Contracts/modals/RedeemerModal.tsx
+++ b/src/components/Contracts/modals/RedeemerModal.tsx
@@ -36,7 +36,7 @@ const RedeemerModal: React.FC<RedeemerModalProps> = ({ open = false, onClose, da
           <Typography>{t("explain.redeemer.desc2")}</Typography>
         </ExplainationDropdown>
         <SlotContainer>
-          <Grid container spacing={2}>
+          <Grid container spacing={2} style={{ marginBottom: " 6px" }}>
             {data &&
               data.length > 0 &&
               data.map((item) => (


### PR DESCRIPTION
## Description


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[MET_2023](https://cardanofoundation.atlassian.net/jira/software/c/projects/MET/boards/33/backlog?selectedIssue=MET-2023)]

### Testing & Validation

- [x] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_

![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/36b0cb78-6347-4db3-bcad-8150f62715bf)

[comment]: <> (Add screenshots)

##### _After_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/51cc319f-3ad1-45df-8577-9d09b41a28cd)


[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_


[comment]: <> (Add screenshots)

#### Responsive
##### _Before_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/288440f4-46dd-4eae-a1d2-61732d1aef67)


[comment]: <> (Add screenshots)

##### _After_
![image](https://github.com/cardano-foundation/cf-explorer-frontend/assets/132549582/f2120647-2c59-426b-a02e-3485ff881223)



[comment]: <> (Add screenshots)