### PR TITLE
fix: tooltip display not in the middle

### DIFF
--- a/src/components/Overview/TabOverview/index.tsx
+++ b/src/components/Overview/TabOverview/index.tsx
@@ -76,7 +76,7 @@ export default function TabOverview() {
           <Box
             component={"span"}
             display={"inline-block"}
-            width={"150px"}
+            maxWidth={"150px"}
             textOverflow={"ellipsis"}
             whiteSpace={"nowrap"}
             overflow={"hidden"}


### PR DESCRIPTION
## Description

Please include a summary of the changes and a brief description about this PR

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in Chrome, Firefox, Safari and Brave browsers.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence / README.md file) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Chrome
##### _Before_
![image](https://github.com/user-attachments/assets/6065b0b9-6bfa-4b6a-8d9b-0bd0397ad60b)


[comment]: <> (Add screenshots)

##### _After_
![image](https://github.com/user-attachments/assets/067ab67b-dedc-4d00-84a7-0a3d2c9cb609)

[comment]: <> (Add screenshots)

#### Safari
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Responsive
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)